### PR TITLE
Move RapidPro configuration to common/configuration

### DIFF
--- a/src/common/configuration.py
+++ b/src/common/configuration.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from core_data_modules.logging import Logger
 from engagement_database import EngagementDatabase
 from id_infrastructure.firestore_uuid_table import FirestoreUuidTable
+from rapid_pro_tools.rapid_pro_client import RapidProClient
 from storage.google_cloud import google_cloud_utils
 
 log = Logger(__name__)
@@ -53,3 +54,19 @@ class UUIDTableConfiguration:
         log.info("Initialised uuid table")
 
         return uuid_table
+
+
+@dataclass
+# TODO: Convert from data-class once design is better tested
+class RapidProConfiguration:
+    domain: str
+    token_file_url: str
+
+    def init_rapid_pro_client(self, google_cloud_credentials_file_path):
+        log.info(f"Initialising Rapid Pro client for domain {self.domain} and auth url {self.token_file_url}...")
+        rapid_pro_token = google_cloud_utils.download_blob_to_string(
+            google_cloud_credentials_file_path, self.token_file_url).strip()
+        rapid_pro_client = RapidProClient(self.domain, rapid_pro_token)
+        log.info("Initialised Rapid Pro client")
+
+        return rapid_pro_client

--- a/src/rapid_pro_to_engagement_db/configuration.py
+++ b/src/rapid_pro_to_engagement_db/configuration.py
@@ -6,10 +6,3 @@ class FlowResultConfiguration:
     flow_name: str
     flow_result_field: str
     engagement_db_dataset: str
-
-
-@dataclass
-class RapidProToEngagementDBConfiguration:
-    domain: str
-    token_file_url: str
-    flow_result_configurations: [FlowResultConfiguration]

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -7,30 +7,6 @@ from storage.google_cloud import google_cloud_utils
 log = Logger(__name__)
 
 
-def init_rapid_pro_client(google_cloud_credentials_file_path, rapid_pro_domain, rapid_pro_token_file_url):
-    """
-    Initialises a RapidProClient from a Rapid Pro domain and token file url.
-
-    :param google_cloud_credentials_file_path: Path to the google cloud credentials file to use to access the
-                                               rapid pro token.
-    :type google_cloud_credentials_file_path: str
-    :param rapid_pro_domain: Domain which Rapid Pro is running on.
-    :type rapid_pro_domain: str
-    :param rapid_pro_token_file_url: GS url to the Rapid Pro token.
-    :type rapid_pro_token_file_url: str
-    :return: RapidProClient for
-    :rtype: rapid_pro_tools.rapid_pro_client.RapidProClient
-    """
-    log.info(f"Initialising Rapid Pro client for domain {rapid_pro_domain} and auth "
-             f"url {rapid_pro_token_file_url}...")
-    rapid_pro_token = google_cloud_utils.download_blob_to_string(
-        google_cloud_credentials_file_path, rapid_pro_token_file_url).strip()
-    rapid_pro_client = RapidProClient(rapid_pro_domain, rapid_pro_token)
-    log.info("Initialised Rapid Pro client")
-
-    return rapid_pro_client
-
-
 def _engagement_db_has_message(engagement_db, message):
     """
     Checks if an engagement database contains a message with the same text, timestamp, and participant_uuid as the
@@ -81,20 +57,18 @@ def _ensure_engagement_db_has_message(engagement_db, message, message_origin_det
     )
 
 
-def sync_rapid_pro_to_engagement_db(google_cloud_credentials_file_path, rapid_pro_to_engagement_db_configuration,
-                                    engagement_db, uuid_table):
+def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, flow_result_configs):
     """
     Synchronises runs from a Rapid Pro workspace to an engagement database.
 
-    :param google_cloud_credentials_file_path: Path to a Google Cloud service account credentials file to use to access
-                                               the credentials bucket.
-    :type google_cloud_credentials_file_path: str
-    :param rapid_pro_to_engagement_db_configuration: Configuration for the sync operation.
-    :type rapid_pro_to_engagement_db_configuration: src.rapid_pro_to_engagement_db.configuration.RapidProToEngagementDBConfiguration
+    :param rapid_pro: Rapid Pro client to sync from.
+    :type rapid_pro: rapid_pro_tools.rapid_pro_client.RapidProClient
     :param engagement_db: Engagement database to sync to.
     :type engagement_db: engagement_database.EngagementDatabase
     :param uuid_table: UUID table to use to de-identify contact urns.
     :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
+    :param flow_result_configs: Configuration for data to sync.
+    :type flow_result_configs: list of rapid_pro_to_engagement_db.FlowResultConfiguration
     """
     # This implementation is WIP. It shows how we can non-incrementally synchronise a workspace to the database.
     # To enter production, we still need the following:
@@ -103,16 +77,13 @@ def sync_rapid_pro_to_engagement_db(google_cloud_credentials_file_path, rapid_pr
     # TODO: Handle contacts that have runs but haven't been fetched locally yet.
     # TODO: Optimise fetching fields from the same flows, so we don't have to download the same runs multiple times.
 
-    rapid_pro = init_rapid_pro_client(google_cloud_credentials_file_path,
-                                      rapid_pro_to_engagement_db_configuration.domain,
-                                      rapid_pro_to_engagement_db_configuration.token_file_url)
     workspace_name = rapid_pro.get_workspace_name()
 
     # Build a look-up table of Rapid Pro contact uuid -> Rapid Pro contact so we can look up the urn for each run later.
     contacts = rapid_pro.get_raw_contacts()
     contacts_lut = {c.uuid: c for c in contacts}
 
-    for flow_config in rapid_pro_to_engagement_db_configuration.flow_result_configurations:
+    for flow_config in flow_result_configs:
         # Get the latest runs for this flow.
         flow_id = rapid_pro.get_flow_id(flow_config.flow_name)
         runs = rapid_pro.get_raw_runs(flow_id)

--- a/sync_rapid_pro_to_engagement_db.py
+++ b/sync_rapid_pro_to_engagement_db.py
@@ -5,7 +5,7 @@ from core_data_modules.logging import Logger
 from engagement_database.data_models import HistoryEntryOrigin
 
 from src.common.configuration import UUIDTableConfiguration, EngagementDatabaseConfiguration, RapidProConfiguration
-from src.rapid_pro_to_engagement_db.configuration import RapidProToEngagementDBConfiguration, FlowResultConfiguration
+from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
 from src.rapid_pro_to_engagement_db.rapid_pro_to_engagement_db import sync_rapid_pro_to_engagement_db
 
 log = Logger(__name__)

--- a/sync_rapid_pro_to_engagement_db.py
+++ b/sync_rapid_pro_to_engagement_db.py
@@ -4,7 +4,7 @@ import subprocess
 from core_data_modules.logging import Logger
 from engagement_database.data_models import HistoryEntryOrigin
 
-from src.common.configuration import UUIDTableConfiguration, EngagementDatabaseConfiguration
+from src.common.configuration import UUIDTableConfiguration, EngagementDatabaseConfiguration, RapidProConfiguration
 from src.rapid_pro_to_engagement_db.configuration import RapidProToEngagementDBConfiguration, FlowResultConfiguration
 from src.rapid_pro_to_engagement_db.rapid_pro_to_engagement_db import sync_rapid_pro_to_engagement_db
 
@@ -40,19 +40,21 @@ if __name__ == "__main__":
         database_path="engagement_db_experiments/experimental_test"
     )
 
-    rapid_pro_config = RapidProToEngagementDBConfiguration(
-        domain="textit.in",
-        token_file_url="gs://avf-credentials/experimental-test-text-it-token.txt",
-        flow_result_configurations=[
-            FlowResultConfiguration("test_pipeline_daniel_activation", "rqa_s01e01", "s01e01"),
-            FlowResultConfiguration("test_pipeline_daniel_demog", "constituency", "location"),
-            FlowResultConfiguration("test_pipeline_daniel_demog", "age", "age"),
-            FlowResultConfiguration("test_pipeline_daniel_demog", "gender", "gender"),
-        ]
+    rapid_pro_config = RapidProConfiguration(
+        domain="textit.com",
+        token_file_url="gs://avf-credentials/experimental-test-text-it-token.txt"
     )
 
+    flow_result_configurations = [
+        FlowResultConfiguration("test_pipeline_daniel_activation", "rqa_s01e01", "s01e01"),
+        FlowResultConfiguration("test_pipeline_daniel_demog", "constituency", "location"),
+        FlowResultConfiguration("test_pipeline_daniel_demog", "age", "age"),
+        FlowResultConfiguration("test_pipeline_daniel_demog", "gender", "gender"),
+    ]
+
+    rapid_pro = rapid_pro_config.init_rapid_pro_client(google_cloud_credentials_file_path)
     uuid_table = uuid_table_configuration.init_uuid_table(google_cloud_credentials_file_path)
     engagement_db = engagement_db_configuration.init_engagement_db(google_cloud_credentials_file_path)
 
-    sync_rapid_pro_to_engagement_db(google_cloud_credentials_file_path, rapid_pro_config, engagement_db, uuid_table)
+    sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, flow_result_configurations)
 


### PR DESCRIPTION
This simplifies and improves the consistency in configuration, as well as making it easier to reuse rapid pro configuration in other tools in future