### PR TITLE
Add pipeline configuration

### DIFF
--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -3,6 +3,7 @@ from src.common.configuration import EngagementDatabaseConfiguration, UUIDTableC
 from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
 
 PIPELINE_CONFIGURATION = PipelineConfiguration(
+    pipeline_name="engagement-db-test",
     engagement_database=EngagementDatabaseConfiguration(
         credentials_file_url="gs://avf-credentials/firebase-test.json",
         database_path="engagement_db_experiments/experimental_test"

--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -1,0 +1,29 @@
+from src.pipeline_configuration_spec import PipelineConfiguration, RapidProSource
+from src.common.configuration import EngagementDatabaseConfiguration, UUIDTableConfiguration, RapidProConfiguration
+from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
+
+PIPELINE_CONFIGURATION = PipelineConfiguration(
+    engagement_database=EngagementDatabaseConfiguration(
+        credentials_file_url="gs://avf-credentials/firebase-test.json",
+        database_path="engagement_db_experiments/experimental_test"
+    ),
+    uuid_table=UUIDTableConfiguration(
+        credentials_file_url="gs://avf-credentials/firebase-test.json",
+        table_name="_engagement_db_test",
+        uuid_prefix="avf-participant-uuid-"
+    ),
+    rapid_pro_sources=[
+        RapidProSource(
+            rapid_pro=RapidProConfiguration(
+                domain="textit.com",
+                token_file_url="gs://avf-credentials/experimental-test-text-it-token.txt"
+            ),
+            flow_results=[
+                FlowResultConfiguration("test_pipeline_daniel_activation", "rqa_s01e01", "s01e01"),
+                FlowResultConfiguration("test_pipeline_daniel_demog", "constituency", "location"),
+                FlowResultConfiguration("test_pipeline_daniel_demog", "age", "age"),
+                FlowResultConfiguration("test_pipeline_daniel_demog", "gender", "gender"),
+            ]
+        )
+    ]
+)

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from src.common.configuration import EngagementDatabaseConfiguration, UUIDTableConfiguration, RapidProConfiguration
+from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
+
+
+@dataclass
+class RapidProSource:
+    rapid_pro: RapidProConfiguration
+    flow_results: [FlowResultConfiguration]
+
+
+@dataclass
+class PipelineConfiguration:
+    engagement_database: EngagementDatabaseConfiguration
+    uuid_table: UUIDTableConfiguration
+    rapid_pro_sources: [RapidProSource] = None

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -12,6 +12,7 @@ class RapidProSource:
 
 @dataclass
 class PipelineConfiguration:
+    pipeline_name: str
     engagement_database: EngagementDatabaseConfiguration
     uuid_table: UUIDTableConfiguration
     rapid_pro_sources: [RapidProSource] = None

--- a/sync_rapid_pro_to_engagement_db.py
+++ b/sync_rapid_pro_to_engagement_db.py
@@ -22,13 +22,14 @@ if __name__ == "__main__":
     user = args.user
     google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
 
-    pipeline = "engagement-db-test"
+    # TODO: Load this from a configuration_file_path argument
+    pipeline_config = test_pipeline_configuration.PIPELINE_CONFIGURATION
+
+    pipeline = pipeline_config.pipeline_name
     commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
     project = subprocess.check_output(["git", "config", "--get", "remote.origin.url"]).decode().strip()
 
     HistoryEntryOrigin.set_defaults(user, project, pipeline, commit)
-
-    pipeline_config = test_pipeline_configuration.PIPELINE_CONFIGURATION
 
     if pipeline_config.rapid_pro_sources is None or len(pipeline_config.rapid_pro_sources) == 0:
         log.info(f"No Rapid Pro sources specified; exiting")


### PR DESCRIPTION
Add a test configuration for a pipeline that syncs from rapid pro workspaces.

(adds as python data classes for now, we can convert to json/add validation later)