### PR TITLE
Sync engagement database -> Rapid Pro

### DIFF
--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -8,7 +8,7 @@ from src.common.configuration import RapidProClientConfiguration, CodaClientConf
 from src.engagement_db_to_coda.configuration import CodaSyncConfiguration, CodaDatasetConfiguration, \
     CodeSchemeConfiguration
 from src.engagement_db_to_rapid_pro.configuration import EngagementDBToRapidProConfiguration, DatasetConfiguration, \
-    SyncModes
+    WriteModes
 from src.pipeline_configuration_spec import PipelineConfiguration, RapidProSource, CodaConfiguration, RapidProTarget
 from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
 
@@ -90,7 +90,7 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 DatasetConfiguration(engagement_db_datasets=["age"], rapid_pro_contact_field="age"),
                 DatasetConfiguration(engagement_db_datasets=["s01e01"], rapid_pro_contact_field="s01e01")
             ],
-            sync_mode=SyncModes.SHOW_PRESENCE
+            write_mode=WriteModes.SHOW_PRESENCE
         )
     )
 )

--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -7,7 +7,9 @@ from src.common.configuration import RapidProClientConfiguration, CodaClientConf
     EngagementDatabaseClientConfiguration
 from src.engagement_db_to_coda.configuration import CodaSyncConfiguration, CodaDatasetConfiguration, \
     CodeSchemeConfiguration
-from src.pipeline_configuration_spec import PipelineConfiguration, RapidProSource, CodaConfiguration
+from src.engagement_db_to_rapid_pro.configuration import EngagementDBToRapidProConfiguration, DatasetConfiguration, \
+    SyncModes
+from src.pipeline_configuration_spec import PipelineConfiguration, RapidProSource, CodaConfiguration, RapidProTarget
 from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
 
 
@@ -72,6 +74,23 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 ),
             ],
             ws_correct_dataset_code_scheme=load_code_scheme("ws_correct_dataset")
+        )
+    ),
+    rapid_pro_target=RapidProTarget(
+        rapid_pro=RapidProClientConfiguration(
+            domain="textit.com",
+            token_file_url="gs://avf-credentials/experimental-sync-test-textit-token.txt"
+        ),
+        sync_config=EngagementDBToRapidProConfiguration(
+            # Note this performs continuous sync of all datasets for the purpose of testing.
+            # In practice, we'd only want to continuously sync consent_withdrawn.
+            normal_datasets=[
+                DatasetConfiguration(engagement_db_datasets=["gender"], rapid_pro_contact_field="gender"),
+                DatasetConfiguration(engagement_db_datasets=["location"], rapid_pro_contact_field="location"),
+                DatasetConfiguration(engagement_db_datasets=["age"], rapid_pro_contact_field="age"),
+                DatasetConfiguration(engagement_db_datasets=["s01e01"], rapid_pro_contact_field="s01e01")
+            ],
+            sync_mode=SyncModes.SHOW_PRESENCE
         )
     )
 )

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 
-class SyncModes:
+class WriteModes:
     # Controls how to write data back to Rapid Pro.
     CONCATENATE_TEXTS = "concatenate_texts"  # Concatenate all the raw messages when writing to a contact field
     SHOW_PRESENCE = "show_presence"          # Write a string showing that we have a message for this contact field
@@ -19,4 +19,4 @@ class DatasetConfiguration:
 class EngagementDBToRapidProConfiguration:
     normal_datasets: Optional[List[DatasetConfiguration]] = None
     # TODO: consent_withdrawn configuration
-    sync_mode: str = SyncModes.SHOW_PRESENCE
+    write_mode: str = WriteModes.SHOW_PRESENCE

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -20,3 +20,6 @@ class EngagementDBToRapidProConfiguration:
     normal_datasets: Optional[List[DatasetConfiguration]] = None
     # TODO: consent_withdrawn configuration
     write_mode: str = WriteModes.SHOW_PRESENCE
+    allow_clearing_fields: bool = False  # Whether to allow setting contact fields to empty. Setting this to True may
+                                         # not be appropriate for continuous sync because a new message may have arrived
+                                         # in Rapid Pro but not yet in the engagement database.

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from typing import Optional, List
+
+
+class SyncModes:
+    # Controls how to write data back to Rapid Pro.
+    CONCATENATE_TEXTS = "concatenate_texts"  # Concatenate all the raw messages when writing to a contact field
+    SHOW_PRESENCE = "show_presence"          # Write a string showing that we have a message for this contact field
+                                             # without writing back the messages themselves.
+
+
+@dataclass
+class DatasetConfiguration:
+    engagement_db_datasets: [str]
+    rapid_pro_contact_field: str
+
+
+@dataclass
+class EngagementDBToRapidProConfiguration:
+    normal_datasets: Optional[List[DatasetConfiguration]] = None
+    # TODO: consent_withdrawn configuration
+    sync_mode: str = SyncModes.SHOW_PRESENCE

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -1,8 +1,3 @@
-import glob
-import json
-
-from core_data_modules.cleaners import Codes
-from core_data_modules.data_models import CodeScheme
 from core_data_modules.logging import Logger
 from engagement_database.data_models import MessageStatuses
 
@@ -61,7 +56,6 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
                     assert sync_config.sync_mode == SyncModes.CONCATENATE_TEXTS
                     contact_fields[dataset_config.rapid_pro_contact_field] = ";".join([m.text for m in messages])
 
-        # TODO: Detect consent_withdrawn
-
+        # TODO: Detect and update consent status
 
         rapid_pro.update_contact(urn, contact_fields=contact_fields)

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -1,7 +1,7 @@
 from core_data_modules.logging import Logger
 from engagement_database.data_models import MessageStatuses
 
-from src.engagement_db_to_rapid_pro.configuration import SyncModes
+from src.engagement_db_to_rapid_pro.configuration import WriteModes
 
 log = Logger(__name__)
 
@@ -65,10 +65,10 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
 
             # TODO: Add a flag for controlling whether to overwrite fields where data doesn't exist
             if len(messages) > 0:
-                if sync_config.sync_mode == SyncModes.SHOW_PRESENCE:
+                if sync_config.write_mode == WriteModes.SHOW_PRESENCE:
                     contact_fields[dataset_config.rapid_pro_contact_field] = _PRESENCE_VALUE
                 else:
-                    assert sync_config.sync_mode == SyncModes.CONCATENATE_TEXTS
+                    assert sync_config.write_mode == WriteModes.CONCATENATE_TEXTS
                     contact_fields[dataset_config.rapid_pro_contact_field] = ";".join([m.text for m in messages])
 
         # TODO: Detect and update consent status

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -1,0 +1,67 @@
+import glob
+import json
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.data_models import CodeScheme
+from core_data_modules.logging import Logger
+from engagement_database.data_models import MessageStatuses
+
+from src.engagement_db_to_rapid_pro.configuration import SyncModes
+
+log = Logger(__name__)
+
+# Value to write to a Rapid Pro contact field if we're only indicating the presence of an answer
+_PRESENCE_VALUE = "#ENGAGEMENT-DATABASE-HAS-RESPONSE"
+
+
+def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_config):
+    # Get all messages to sync.
+    # Only sync live messages. Anything else means we should signal Rapid Pro to request the data again if it can.
+    # TODO: This could get expensive as the number of datasets increases, in which case we can optimise by adding
+    #       an array-contains filter on the dataset field, so we only need to download messages in the datasets we
+    #       want to sync.
+    messages = engagement_db.get_messages(filter=lambda q: q.where("status", "in", [MessageStatuses.LIVE]))
+
+    # Organise messages by participant then by engagement db dataset.
+    participants = dict()  # of participant_uuid -> (dict of dataset -> list of Message)
+    for msg in messages:
+        if msg.participant_uuid not in participants:
+            participants[msg.participant_uuid] = dict()
+        participant = participants[msg.participant_uuid]
+
+        if msg.dataset not in participant:
+            participant[msg.dataset] = []
+        dataset = participant[msg.dataset]
+
+        dataset.append(msg)
+
+    # Make sure all the contact fields exist in the Rapid Pro workspace
+    existing_contact_fields = [f.key for f in rapid_pro.get_fields()]
+    contact_fields_to_sync = [dataset_config.rapid_pro_contact_field for dataset_config in sync_config.normal_datasets]
+    for contact_field in contact_fields_to_sync:
+        if contact_field not in existing_contact_fields:
+            rapid_pro.create_field(contact_field)
+
+    # Sync each participant to Rapid Pro
+    for participant_uuid, datasets in participants.items():
+        log.info(f"Syncing {participant_uuid}...")
+        urn = uuid_table.uuid_to_data(participant_uuid)
+
+        contact_fields = dict()
+        for dataset_config in sync_config.normal_datasets:
+            messages = []
+            for dataset in dataset_config.engagement_db_datasets:
+                messages.extend(datasets.get(dataset, []))
+
+            # TODO: Add a flag for controlling whether to overwrite fields where data doesn't exist
+            if len(messages) > 0:
+                if sync_config.sync_mode == SyncModes.SHOW_PRESENCE:
+                    contact_fields[dataset_config.rapid_pro_contact_field] = _PRESENCE_VALUE
+                else:
+                    assert sync_config.sync_mode == SyncModes.CONCATENATE_TEXTS
+                    contact_fields[dataset_config.rapid_pro_contact_field] = ";".join([m.text for m in messages])
+
+        # TODO: Detect consent_withdrawn
+
+
+        rapid_pro.update_contact(urn, contact_fields=contact_fields)

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -30,20 +30,23 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
 
         dataset.append(msg)
 
-    # Make sure all the contact fields exist in the Rapid Pro workspace
+    # Make sure all the contact fields exist in the Rapid Pro workspace.
     existing_contact_fields = [f.key for f in rapid_pro.get_fields()]
     contact_fields_to_sync = [dataset_config.rapid_pro_contact_field for dataset_config in sync_config.normal_datasets]
     for contact_field in contact_fields_to_sync:
         if contact_field not in existing_contact_fields:
             rapid_pro.create_field(contact_field)
 
-    # Sync each participant to Rapid Pro
+    # Sync each participant to Rapid Pro.
     for i, (participant_uuid, datasets) in enumerate(participants.items()):
         log.info(f"Syncing participant {i + 1}/{len(participants)}: {participant_uuid}...")
+        # Re-identify the participant
         urn = uuid_table.uuid_to_data(participant_uuid)
 
+        # Build a dictionary of contact_field -> value to write for each normal dataset.
         contact_fields = dict()
         for dataset_config in sync_config.normal_datasets:
+            # Find all the messages from this participant that are relevant to this dataset.
             messages = []
             for dataset in dataset_config.engagement_db_datasets:
                 messages.extend(datasets.get(dataset, []))
@@ -58,4 +61,5 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
 
         # TODO: Detect and update consent status
 
+        # Write the contact fields to rapid pro
         rapid_pro.update_contact(urn, contact_fields=contact_fields)

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -74,6 +74,8 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
                 contact_fields[dataset_config.rapid_pro_contact_field] = ""
 
         # TODO: Detect and update consent status
-# TODO: Update special group membership status e.g listening groups
+
+        # TODO: Update special group membership status e.g listening groups
+
         # Write the contact fields to rapid pro
         rapid_pro.update_contact(urn, contact_fields=contact_fields)

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -38,8 +38,8 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
             rapid_pro.create_field(contact_field)
 
     # Sync each participant to Rapid Pro
-    for participant_uuid, datasets in participants.items():
-        log.info(f"Syncing {participant_uuid}...")
+    for i, (participant_uuid, datasets) in enumerate(participants.items()):
+        log.info(f"Syncing participant {i + 1}/{len(participants)}: {participant_uuid}...")
         urn = uuid_table.uuid_to_data(participant_uuid)
 
         contact_fields = dict()

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -74,6 +74,6 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
                 contact_fields[dataset_config.rapid_pro_contact_field] = ""
 
         # TODO: Detect and update consent status
-
+# TODO: Update special group membership status e.g listening groups
         # Write the contact fields to rapid pro
         rapid_pro.update_contact(urn, contact_fields=contact_fields)

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -10,6 +10,18 @@ _PRESENCE_VALUE = "#ENGAGEMENT-DATABASE-HAS-RESPONSE"
 
 
 def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_config):
+    """
+    Synchronises an engagement database to Rapid Pro.
+
+    :param engagement_db: Engagement database to sync to.
+    :type engagement_db: engagement_database.EngagementDatabase
+    :param rapid_pro: Rapid Pro client to sync from.
+    :type rapid_pro: rapid_pro_tools.rapid_pro_client.RapidProClient
+    :param uuid_table: UUID table to use to de-identify contact urns.
+    :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
+    :param sync_config: Configuration for the sync.
+    :type sync_config: src.engagement_db_to_rapid_pro.configuration.EngagementDBToRapidProConfiguration
+    """
     # Get all messages to sync.
     # Only sync live messages. Anything else means we should signal Rapid Pro to request the data again if it can.
     # TODO: This could get expensive as the number of datasets increases, in which case we can optimise by adding

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -64,12 +64,14 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
                 messages.extend(datasets.get(dataset, []))
 
             # Only overwrite this contact field if there is data to write or it's ok to clear a field.
-            if len(messages) > 0 or sync_config.allow_clearing_fields:
+            if len(messages) > 0:
                 if sync_config.write_mode == WriteModes.SHOW_PRESENCE:
                     contact_fields[dataset_config.rapid_pro_contact_field] = _PRESENCE_VALUE
                 else:
                     assert sync_config.write_mode == WriteModes.CONCATENATE_TEXTS
                     contact_fields[dataset_config.rapid_pro_contact_field] = ";".join([m.text for m in messages])
+            elif sync_config.allow_clearing_fields:
+                contact_fields[dataset_config.rapid_pro_contact_field] = ""
 
         # TODO: Detect and update consent status
 

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -63,8 +63,8 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
             for dataset in dataset_config.engagement_db_datasets:
                 messages.extend(datasets.get(dataset, []))
 
-            # TODO: Add a flag for controlling whether to overwrite fields where data doesn't exist
-            if len(messages) > 0:
+            # Only overwrite this contact field if there is data to write or it's ok to clear a field.
+            if len(messages) > 0 or sync_config.allow_clearing_fields:
                 if sync_config.write_mode == WriteModes.SHOW_PRESENCE:
                     contact_fields[dataset_config.rapid_pro_contact_field] = _PRESENCE_VALUE
                 else:

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from src.common.configuration import RapidProClientConfiguration, EngagementDatabaseClientConfiguration, \
     UUIDTableClientConfiguration, CodaClientConfiguration
 from src.engagement_db_to_coda.configuration import CodaSyncConfiguration
+from src.engagement_db_to_rapid_pro.configuration import EngagementDBToRapidProConfiguration
 from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
 
 
@@ -19,9 +20,16 @@ class CodaConfiguration:
 
 
 @dataclass
+class RapidProTarget:
+    rapid_pro: RapidProClientConfiguration
+    sync_config: EngagementDBToRapidProConfiguration
+
+
+@dataclass
 class PipelineConfiguration:
     pipeline_name: str
     engagement_database: EngagementDatabaseClientConfiguration
     uuid_table: UUIDTableClientConfiguration
     rapid_pro_sources: [RapidProSource] = None
     coda_sync: CodaConfiguration = None
+    rapid_pro_target: RapidProTarget = None

--- a/sync_engagement_db_to_rapid_pro.py
+++ b/sync_engagement_db_to_rapid_pro.py
@@ -3,11 +3,8 @@ import subprocess
 
 from core_data_modules.logging import Logger
 from engagement_database.data_models import HistoryEntryOrigin
-from rapid_pro_tools.rapid_pro_client import RapidProClient
 
 from configurations import test_pipeline_configuration
-from src.engagement_db_to_rapid_pro.configuration import DatasetConfiguration, EngagementDBToRapidProConfiguration, \
-    SyncModes
 from src.engagement_db_to_rapid_pro.engagement_db_to_rapid_pro import sync_engagement_db_to_rapid_pro
 
 log = Logger(__name__)

--- a/sync_engagement_db_to_rapid_pro.py
+++ b/sync_engagement_db_to_rapid_pro.py
@@ -1,0 +1,41 @@
+import argparse
+import subprocess
+
+from core_data_modules.logging import Logger
+from engagement_database.data_models import HistoryEntryOrigin
+from rapid_pro_tools.rapid_pro_client import RapidProClient
+
+from configurations import test_pipeline_configuration
+from src.engagement_db_to_rapid_pro.configuration import DatasetConfiguration, EngagementDBToRapidProConfiguration, \
+    SyncModes
+from src.engagement_db_to_rapid_pro.engagement_db_to_rapid_pro import sync_engagement_db_to_rapid_pro
+
+log = Logger(__name__)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Syncs data from an engagement database to Rapid Pro")
+
+    parser.add_argument("user", help="Identifier of the user launching this program")
+    parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
+                        help="Path to a Google Cloud service account credentials file to use to access the "
+                             "credentials bucket")
+
+    args = parser.parse_args()
+
+    user = args.user
+    google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
+    # TODO: Load this from a configuration_file_path argument
+    pipeline_config = test_pipeline_configuration.PIPELINE_CONFIGURATION
+
+    pipeline = pipeline_config.pipeline_name
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+    project = subprocess.check_output(["git", "config", "--get", "remote.origin.url"]).decode().strip()
+
+    HistoryEntryOrigin.set_defaults(user, project, pipeline, commit)
+
+    uuid_table = pipeline_config.uuid_table.init_uuid_table_client(google_cloud_credentials_file_path)
+    engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
+    rapid_pro = pipeline_config.rapid_pro_target.rapid_pro.init_rapid_pro_client(google_cloud_credentials_file_path)
+    sync_config = pipeline_config.rapid_pro_target.sync_config
+
+    sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_config)


### PR DESCRIPTION
Prototype implementation of sync from an engagement database to a Rapid Pro workspace. This syncs normal fields only, I'll add support for setting a consent_withdrawn field in another PR.

Note that this is designing for two modes of operation - a realtime sync, probably for consent only, and as one-off manual tool runs, e.g. for syncing the database to a new workspace or for when we've marked data as stale every so often. 