### PR TITLE
 Update the Rapid Pro contact field configuration to take keys and labels

### DIFF
--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -8,7 +8,7 @@ from src.common.configuration import RapidProClientConfiguration, CodaClientConf
 from src.engagement_db_to_coda.configuration import CodaSyncConfiguration, CodaDatasetConfiguration, \
     CodeSchemeConfiguration
 from src.engagement_db_to_rapid_pro.configuration import EngagementDBToRapidProConfiguration, DatasetConfiguration, \
-    WriteModes
+    WriteModes, ContactField
 from src.pipeline_configuration_spec import PipelineConfiguration, RapidProSource, CodaConfiguration, RapidProTarget
 from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
 
@@ -85,10 +85,10 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
             # Note this performs continuous sync of all datasets for the purpose of testing.
             # In practice, we'd only want to continuously sync consent_withdrawn.
             normal_datasets=[
-                DatasetConfiguration(engagement_db_datasets=["gender"], rapid_pro_contact_field="gender"),
-                DatasetConfiguration(engagement_db_datasets=["location"], rapid_pro_contact_field="location"),
-                DatasetConfiguration(engagement_db_datasets=["age"], rapid_pro_contact_field="age"),
-                DatasetConfiguration(engagement_db_datasets=["s01e01"], rapid_pro_contact_field="s01e01")
+                DatasetConfiguration(engagement_db_datasets=["gender"],   rapid_pro_contact_field=ContactField(key="gender",   label="Gender")),
+                DatasetConfiguration(engagement_db_datasets=["location"], rapid_pro_contact_field=ContactField(key="location", label="Location")),
+                DatasetConfiguration(engagement_db_datasets=["age"],      rapid_pro_contact_field=ContactField(key="age",      label="Age")),
+                DatasetConfiguration(engagement_db_datasets=["s01e01"],   rapid_pro_contact_field=ContactField(key="s01e01",   label="Test S01E01"))
             ],
             write_mode=WriteModes.SHOW_PRESENCE
         )

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -10,9 +10,15 @@ class WriteModes:
 
 
 @dataclass
+class ContactField:
+    key: str
+    label: str
+
+
+@dataclass
 class DatasetConfiguration:
     engagement_db_datasets: [str]
-    rapid_pro_contact_field: str
+    rapid_pro_contact_field: ContactField
 
 
 @dataclass

--- a/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
+++ b/src/engagement_db_to_rapid_pro/engagement_db_to_rapid_pro.py
@@ -43,11 +43,11 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
         dataset.append(msg)
 
     # Make sure all the contact fields exist in the Rapid Pro workspace.
-    existing_contact_fields = [f.key for f in rapid_pro.get_fields()]
+    existing_contact_field_keys = [f.key for f in rapid_pro.get_fields()]
     contact_fields_to_sync = [dataset_config.rapid_pro_contact_field for dataset_config in sync_config.normal_datasets]
     for contact_field in contact_fields_to_sync:
-        if contact_field not in existing_contact_fields:
-            rapid_pro.create_field(contact_field)
+        if contact_field.key not in existing_contact_field_keys:
+            rapid_pro.create_field(contact_field.label, contact_field.key)
 
     # Sync each participant to Rapid Pro.
     for i, (participant_uuid, datasets) in enumerate(participants.items()):
@@ -66,12 +66,12 @@ def sync_engagement_db_to_rapid_pro(engagement_db, rapid_pro, uuid_table, sync_c
             # Only overwrite this contact field if there is data to write or it's ok to clear a field.
             if len(messages) > 0:
                 if sync_config.write_mode == WriteModes.SHOW_PRESENCE:
-                    contact_fields[dataset_config.rapid_pro_contact_field] = _PRESENCE_VALUE
+                    contact_fields[dataset_config.rapid_pro_contact_field.key] = _PRESENCE_VALUE
                 else:
                     assert sync_config.write_mode == WriteModes.CONCATENATE_TEXTS
-                    contact_fields[dataset_config.rapid_pro_contact_field] = ";".join([m.text for m in messages])
+                    contact_fields[dataset_config.rapid_pro_contact_field.key] = ";".join([m.text for m in messages])
             elif sync_config.allow_clearing_fields:
-                contact_fields[dataset_config.rapid_pro_contact_field] = ""
+                contact_fields[dataset_config.rapid_pro_contact_field.key] = ""
 
         # TODO: Detect and update consent status
 


### PR DESCRIPTION
Previously we were just configuring the contact field keys, but we need both so we can create labels with the correct label where they don't exist. This also makes the configuration clearer, as it isn't obvious on the current main branch that the contact field configuration needed to be keys.