### PR TITLE
Enable incremental mode for rapid pro -> engagement db sync

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "master"}
-RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "allow-prev-raw-data-none"}
+RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "master"}
 CodaV2PythonClient = {editable = true,git = "https://www.github.com/AfricasVoices/CodaV2PythonClient",ref = "msg-get-add-experiment"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "master"}
 

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "master"}
-RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "skip-empty-archives"}
+RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "allow-prev-raw-data-none"}
 CodaV2PythonClient = {editable = true,git = "https://www.github.com/AfricasVoices/CodaV2PythonClient",ref = "msg-get-add-experiment"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "master"}
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c025bbc821188a5863bcd1515d5509d5ee9e1d4677c7343eaa7765823e74b2f8"
+            "sha256": "24a891fa418500a480c361227d93e8296468082263f1878c801a1377e6398289"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -357,7 +357,7 @@
         "pipelineinfrastructure": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",
-            "ref": "7139a0ea3b0a3c7da6557fa159c8a3ee2de97796"
+            "ref": "bb273bc6ae76a00cf417dff6a9331b6ce5774a34"
         },
         "proto-plus": {
             "hashes": [
@@ -473,7 +473,7 @@
         "rapidprotools": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/RapidProTools",
-            "ref": "663c854b748c02ffd0097ed7ab249246ceefec67"
+            "ref": "553ae92c0d6a319a325ba8fe45fbc0b335b2d884"
         },
         "requests": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b807a8a7becd96ffef70de98012b49919bd0d011b6be0fa79262bca7087b81c0"
+            "sha256": "c025bbc821188a5863bcd1515d5509d5ee9e1d4677c7343eaa7765823e74b2f8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -108,8 +108,8 @@
         },
         "coredatamodules": {
             "editable": true,
-            "git": "https://www.github.com/AfricasVoices/CoreDataModules",
-            "ref": "399f33d18c34172b3bc95fbd932835c1ddfe5f37"
+            "git": "https://github.com/AfricasVoices/CoreDataModules",
+            "ref": "dfa6b52af748bbb232424c3ee524d7a3ec3c454f"
         },
         "firebase-admin": {
             "hashes": [
@@ -124,27 +124,27 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:dbe885011111a9afd9ea9a347db6a9c608e82e5c7648c1f7fabf2b4079a579b5",
-                "sha256:f83118319d2a28806ec3399671cbe4af5351bd0dac54c40a0395da6162ebe324"
+                "sha256:0724d354d394b3d763bc10dfee05807813c5210f0bd9b8e2ddf6b6925603411c",
+                "sha256:92cd9e9f366e84bfcf2524e34d2dc244906c645e731962617ba620da1620a1e0"
             ],
             "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==1.29.0"
+            "version": "==1.30.0"
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:9879b8d1d18212ae92b35bab61e8ea9ed5ea63ef9c8ca847938538da10dd193b",
-                "sha256:ee59ceea417781d1c68c9ea9b9af41b4bd5a4008ae3008cfc70b2623c3bba76a"
+                "sha256:a4aa6152259502adf0bef2d2e67a891de0cd4ce4e9005f17c1566301e02abf7b",
+                "sha256:fccd97eb5143c7c6fd199eef36782c5432f65b28eb212048b22aa56fe028b420"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.7.0"
+            "version": "==2.8.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:044d81b1e58012f8ebc71cc134e191c1fa312f543f1fbc99973afe28c25e3228",
-                "sha256:b3ca7a8ff9ab3bdefee3ad5aefb11fc6485423767eee016f5942d8e606ca23fb"
+                "sha256:154f7889c5d679a6f626f36adb12afbd4dbb0a9a04ec575d989d6ba79c4fd65e",
+                "sha256:6d47c79b5d09fbc7e8355fd9594cc4cf65fdde5d401c63951eaac4baa1ba2ae1"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.30.1"
+            "version": "==1.31.0"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -369,31 +369,31 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:0b5a73fa43efda0df0191c162680ec40cef45463fa8ff69fbeaeeddda4c760f5",
-                "sha256:1e08da38d56b74962d9cb05d86ca5f25d2e5b78f05fd00db7900cad3faa6de00",
-                "sha256:38b2c6e2204731cfebdb2452ffb7addf0367172b35cff8ccda338ccea9e7c87a",
-                "sha256:42239d47f213f1ce12ddca62c0c70856efbac09797d715e5d606b3fbc3f16c44",
-                "sha256:45cc0197e9f9192693c8a4dbcba8c9227a53a2720fc3826dfe791113d9ff5e5e",
-                "sha256:4da073b6c1a83e4ff1294156844f21343c5094e295c194d8ecc94703c7a6f42a",
-                "sha256:4e62be28dcaab52c7e8e8e3fb9a7005dec6374e698f3b22d79276d95c13151e5",
-                "sha256:50c657a54592c1bec7b24521fdbbbd2f7b51325ba23ab505ed03e8ebf3a5aeff",
-                "sha256:557e16884d7276caf92c1fb188fe6dfbec47891d3507d4982db1e3d89ffd22de",
-                "sha256:5a3450acf046716e4a4f02a3f7adfb7b86f1b5b3ae392cec759915e79538d40d",
-                "sha256:6388e7f300010ea7ac77113c7491c5622645d2447fdf701cbfe026b832d728cd",
-                "sha256:744f5c9a3b9e7538c4c70f2b0e46f86858b684f5d17bf78643a19a6c21c7936f",
-                "sha256:751d71dc6559dd794d309811d8dcf179d6a128b38a1655ae7137530f33895cb4",
-                "sha256:816fe5e8b73c29adb13a57e1653da15f24cbb90e86ea92e6f08abe6d8c0cbdb4",
-                "sha256:89613ec119fdcad992f65d7a5bfe3170c17edc839982d0089fc0c9242fb8e517",
-                "sha256:993814b0199f22523a227696a8e20d2cd4b9cda60c76d2fb3969ce0c77eb9e0f",
-                "sha256:9dc01ddc3b195c4538942790c4b195cf17b52d3785a60c1f6f25b794f51e2071",
-                "sha256:b667ddbb77ff619fdbd18be75445d4448ee68493c9bddd1b4d0b177025e2f6f6",
-                "sha256:c2038dec269b65683f16057886c09ca7526471793029bdd43259282e1e0fb668",
-                "sha256:c303ce92c60d069237cfbd41790fde3d00066ca9500fac464454e20c2f12250c",
-                "sha256:c49e673436e24e925022c090a98905cfe88d056cb5dde67a8e20ae339acd8140",
-                "sha256:c5b512c1982f8b427a302db094cf79f8f235284014d01b23fba461aa2c1459a0",
-                "sha256:f3f057ad59cd4d5ea2b1bb88d36c6f009b8043007cf03d96cbd3b9c06859d4fa"
+                "sha256:13ee7be3c2d9a5d2b42a1030976f760f28755fcf5863c55b1460fd205e6cd637",
+                "sha256:145ce0af55c4259ca74993ddab3479c78af064002ec8227beb3d944405123c71",
+                "sha256:14c1c9377a7ffbeaccd4722ab0aa900091f52b516ad89c4b0c3bb0a4af903ba5",
+                "sha256:1556a1049ccec58c7855a78d27e5c6e70e95103b32de9142bae0576e9200a1b0",
+                "sha256:26010f693b675ff5a1d0e1bdb17689b8b716a18709113288fead438703d45539",
+                "sha256:2ae692bb6d1992afb6b74348e7bb648a75bb0d3565a3f5eea5bec8f62bd06d87",
+                "sha256:2bfb815216a9cd9faec52b16fd2bfa68437a44b67c56bee59bc3926522ecb04e",
+                "sha256:4ffbd23640bb7403574f7aff8368e2aeb2ec9a5c6306580be48ac59a6bac8bde",
+                "sha256:6902a1e4b7a319ec611a7345ff81b6b004b36b0d2196ce7a748b3493da3d226d",
+                "sha256:6ce4d8bf0321e7b2d4395e253f8002a1a5ffbcfd7bcc0a6ba46712c07d47d0b4",
+                "sha256:6d847c59963c03fd7a0cd7c488cadfa10cda4fff34d8bc8cba92935a91b7a037",
+                "sha256:72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b",
+                "sha256:7a4c97961e9e5b03a56f9a6c82742ed55375c4a25f2692b625d4087d02ed31b9",
+                "sha256:8727ee027157516e2c311f218ebf2260a18088ffb2d29473e82add217d196b1c",
+                "sha256:99938f2a2d7ca6563c0ade0c5ca8982264c484fdecf418bd68e880a7ab5730b1",
+                "sha256:9b7a5c1022e0fa0dbde7fd03682d07d14624ad870ae52054849d8960f04bc764",
+                "sha256:a22b3a0dbac6544dacbafd4c5f6a29e389a50e3b193e2c70dae6bbf7930f651d",
+                "sha256:a981222367fb4210a10a929ad5983ae93bd5a050a0824fc35d6371c07b78caf6",
+                "sha256:ab6bb0e270c6c58e7ff4345b3a803cc59dbee19ddf77a4719c5b635f1d547aa8",
+                "sha256:c56c050a947186ba51de4f94ab441d7f04fcd44c56df6e922369cc2e1a92d683",
+                "sha256:e76d9686e088fece2450dbc7ee905f9be904e427341d289acbe9ad00b78ebd47",
+                "sha256:f0e59430ee953184a703a324b8ec52f571c6c4259d496a19d1cabcdc19dabc62",
+                "sha256:ffea251f5cd3c0b9b43c7a7a912777e0bc86263436a87c2555242a348817221b"
             ],
-            "version": "==3.17.2"
+            "version": "==3.17.3"
         },
         "pyasn1": {
             "hashes": [
@@ -473,7 +473,7 @@
         "rapidprotools": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/RapidProTools",
-            "ref": "89ad8b57a204cfd6548308a91e71f860af67f1dc"
+            "ref": "663c854b748c02ffd0097ed7ab249246ceefec67"
         },
         "requests": {
             "hashes": [

--- a/src/rapid_pro_to_engagement_db/cache.py
+++ b/src/rapid_pro_to_engagement_db/cache.py
@@ -7,12 +7,28 @@ from temba_client.v2 import Contact
 
 class RapidProSyncCache(object):
     def __init__(self, cache_dir):
+        """
+        Initialises a Rapid Pro sync cache at the given directory.
+
+        The sync cache can be used to locally save/retrieve data needed to enable incremental running of a
+        Rapid Pro -> Engagement Database sync tool.
+
+        :param cache_dir: Directory to use for the cache.
+        :type cache_dir: str
+        """
+
         self.cache_dir = cache_dir
 
     def _contacts_path(self):
         return f"{self.cache_dir}/contacts.json"
 
     def get_contacts(self):
+        """
+        Gets cached contacts.
+
+        :return: Cached contacts, or None if there is no cache yet.
+        :rtype: list of temba_client.v2.Contact | None
+        """
         try:
             with open(self._contacts_path()) as f:
                 return [Contact.deserialize(d) for d in json.load(f)]
@@ -20,17 +36,49 @@ class RapidProSyncCache(object):
             return None
 
     def set_contacts(self, contacts):
-        IOUtils.ensure_dirs_exist_for_file(self._contacts_path())
-        with open(self._contacts_path(), "w") as f:
+        """
+        Sets cached contacts.
+
+        :return: Contacts to write to the cache.
+        :rtype: list of temba_client.v2.Contact | None
+        """
+        export_path = self._contacts_path()
+        IOUtils.ensure_dirs_exist_for_file(export_path)
+        with open(export_path, "w") as f:
             json.dump([c.serialize() for c in contacts], f)
 
-    def get_flow_last_updated(self, flow_id, result_field):
+    def _latest_run_timestamp_path(self, flow_id, result_field):
+        return f"{self.cache_dir}/latest_seen_run_{flow_id}_{result_field}.txt"
+
+    def get_latest_run_timestamp(self, flow_id, result_field):
+        """
+        Gets the latest seen run.modified_on cache for the given flow_id and result_field context.
+
+        :param flow_id: Flow id.
+        :type flow_id: str
+        :param result_field: Flow result field.
+        :type result_field: str
+        :return: Cached latest run timestamp, or None if there is no cache yet for this context.
+        :rtype: datetime.datetime | None
+        """
         try:
-            with open(f"{self.cache_dir}/flow-{flow_id}-{result_field}-last-updated.txt") as f:
+            with open(self._latest_run_timestamp_path(flow_id, result_field)) as f:
                 return datetime.fromisoformat(f.read())
         except FileNotFoundError:
             return None
 
-    def set_flow_last_updated(self, flow_id, result_field, last_updated):
-        with open(f"{self.cache_dir}/flow-{flow_id}-{result_field}-last-updated.txt", "w") as f:
+    def set_latest_run_timestamp(self, flow_id, result_field, last_updated):
+        """
+        Sets the latest seen run.modified_on cache for the given flow_id and result_field context.
+
+        :param flow_id: Flow id.
+        :type flow_id: str
+        :param result_field: Flow result field.
+        :type result_field: str
+        :return: Latest run timestamp.
+        :rtype: datetime.datetime
+        """
+        export_path = self._latest_run_timestamp_path(flow_id, result_field)
+        IOUtils.ensure_dirs_exist_for_file(export_path)
+        with open(export_path, "w") as f:
             f.write(last_updated.isoformat())

--- a/src/rapid_pro_to_engagement_db/cache.py
+++ b/src/rapid_pro_to_engagement_db/cache.py
@@ -5,7 +5,7 @@ from core_data_modules.util import IOUtils
 from temba_client.v2 import Contact
 
 
-class RapidProSyncCache(object):
+class RapidProSyncCache:
     def __init__(self, cache_dir):
         """
         Initialises a Rapid Pro sync cache at the given directory.

--- a/src/rapid_pro_to_engagement_db/cache.py
+++ b/src/rapid_pro_to_engagement_db/cache.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+import json
+
+from core_data_modules.util import IOUtils
+from temba_client.v2 import Contact
+
+
+class RapidProSyncCache(object):
+    def __init__(self, cache_dir):
+        self.cache_dir = cache_dir
+
+    def _contacts_path(self):
+        return f"{self.cache_dir}/contacts.json"
+
+    def get_contacts(self):
+        try:
+            with open(self._contacts_path()) as f:
+                return [Contact.deserialize(d) for d in json.load(f)]
+        except FileNotFoundError:
+            return None
+
+    def set_contacts(self, contacts):
+        IOUtils.ensure_dirs_exist_for_file(self._contacts_path())
+        with open(self._contacts_path(), "w") as f:
+            json.dump([c.serialize() for c in contacts], f)
+
+    def get_flow_last_updated(self, flow_id, result_field):
+        try:
+            with open(f"{self.cache_dir}/flow-{flow_id}-{result_field}-last-updated.txt") as f:
+                return datetime.fromisoformat(f.read())
+        except FileNotFoundError:
+            return None
+
+    def set_flow_last_updated(self, flow_id, result_field, last_updated):
+        with open(f"{self.cache_dir}/flow-{flow_id}-{result_field}-last-updated.txt", "w") as f:
+            f.write(last_updated.isoformat())

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -9,6 +9,50 @@ from src.rapid_pro_to_engagement_db.cache import RapidProSyncCache
 log = Logger(__name__)
 
 
+def _get_contacts_from_cache(cache=None):
+    """
+    :param cache: Cache to check for contacts. If None, returns None.
+    :type cache: src.rapid_pro_to_engagement_db.cache.RapidProSyncCache | None
+    :return: Contacts from a cache, if the cache exists and a previous contacts file exists in the cache, else None.
+    :rtype: list of temba_client.v2.Contact | None
+    """
+    if cache is None:
+        return None
+    else:
+        return cache.get_contacts()
+
+
+def _get_new_runs(rapid_pro, flow_id, flow_result_field, cache=None):
+    """
+    Gets new runs from Rapid Pro for the given flow.
+
+    If a cache is provided and it contains a timestamp of a previous export, only returns runs that have been modified
+    since the last export.
+
+    :param rapid_pro: Rapid Pro client to use to download new runs.
+    :type rapid_pro: rapid_pro_tools.rapid_pro_client.RapidProClient
+    :param flow_id: Flow id to download runs for.
+    :type flow_id: str
+    :param flow_result_field: Result field in the flow.
+    :type flow_result_field: str
+    :param cache: Cache to check for a timestamp of a previous export. If None, downloads all runs.
+    :type cache: src.rapid_pro_to_engagement_db.cache.RapidProSyncCache | None
+    :return: Runs modified for the given flow since the cache was last updated, if possible, else from all of time.
+    :rtype: list of temba_client.v2.Run
+    """
+    # Try to get the last modified timestamp from the cache
+    flow_last_updated = None
+    if cache is not None:
+        flow_last_updated = cache.get_latest_run_timestamp(flow_id, flow_result_field)
+
+    # If there is a last updated timestamp in the cache, only download and return runs that have been modified since.
+    filter_last_modified_after = None
+    if flow_last_updated is not None:
+        filter_last_modified_after = flow_last_updated + timedelta(microseconds=1)
+
+    return rapid_pro.get_raw_runs(flow_id, last_modified_after_inclusive=filter_last_modified_after)
+
+
 def _engagement_db_has_message(engagement_db, message):
     """
     Checks if an engagement database contains a message with the same text, timestamp, and participant_uuid as the
@@ -71,56 +115,52 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, flow_r
     :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
     :param flow_result_configs: Configuration for data to sync.
     :type flow_result_configs: list of rapid_pro_to_engagement_db.FlowResultConfiguration
+    :param cache_path: Path to a directory to use to cache results needed for incremental operation.
+                       If None, runs in non-incremental mode
+    :type cache_path: str | None
     """
     # This implementation is WIP. It shows how we can non-incrementally synchronise a workspace to the database.
     # To enter production, we still need the following:
-    # TODO: Support incremental update of runs and contacts.
     # TODO: Handle deleted contacts.
-    # TODO: Handle contacts that have runs but haven't been fetched locally yet.
     # TODO: Optimise fetching fields from the same flows, so we don't have to download the same runs multiple times.
-
     workspace_name = rapid_pro.get_workspace_name()
 
-    cache = None
     if cache_path is not None:
+        log.info(f"Initialising Rapid Pro sync cache at '{cache_path}/{workspace_name}'")
         cache = RapidProSyncCache(f"{cache_path}/{workspace_name}")
-
-    # Load all the contacts in the Rapid Pro workspace, either from the cache or from Rapid Pro
-    if cache is None:
-        contacts = rapid_pro.get_raw_contacts()
     else:
-        contacts = cache.get_contacts()
-        if contacts is None:
-            contacts = rapid_pro.get_raw_contacts()
+        log.warning("No `cache_path` provided. This tool will process all relevant runs from Rapid Pro from all of time")
+        cache = None
+
+    # Load contacts from the cache if possible.
+    # (If the cache or a contacts file for this workspace don't exist, `contacts` will be `None` for now)
+    contacts = _get_contacts_from_cache(cache)
 
     for flow_config in flow_result_configs:
         # Get the latest runs for this flow.
         flow_id = rapid_pro.get_flow_id(flow_config.flow_name)
-        flow_last_updated = None
-        if cache is not None:
-            flow_last_updated = cache.get_flow_last_updated(flow_id, flow_config.flow_result_field)
-        fetch_since = None
-        if flow_last_updated is not None:
-            fetch_since = flow_last_updated + timedelta(microseconds=1)
-        runs = rapid_pro.get_raw_runs(flow_id, last_modified_after_inclusive=fetch_since)
+        runs = _get_new_runs(rapid_pro, flow_id, flow_config.flow_result_field, cache)
 
-        # Get any contacts that have been updated since we last asked, in case of the downloaded runs are for very
+        # Get any contacts that have been updated since we last asked, in case any of the downloaded runs are for very
         # new contacts.
         contacts = rapid_pro.update_raw_contacts_with_latest_modified(contacts)
         if cache is not None:
             cache.set_contacts(contacts)
         contacts_lut = {c.uuid: c for c in contacts}
 
+        # Process each run in turn, adding it the engagement database if it contains a message relevant to this flow
+        # config and the message hasn't already been added to the engagement database.
+        log.info(f"Processing {len(runs)} new runs for flow '{flow_config.flow_name}'")
         for i, run in enumerate(runs):
             log.debug(f"Processing run {i + 1}/{len(runs)}, id {run.id}...")
-
-            if cache is not None and (flow_last_updated is None or run.modified_on > flow_last_updated):
-                flow_last_updated = run.modified_on
 
             # Get the relevant result from this run, if it exists.
             rapid_pro_result = run.values.get(flow_config.flow_result_field)
             if rapid_pro_result is None:
                 log.debug("No relevant run result")
+                # Update the cache so we know not to check this run again in this flow + result field context.
+                if cache is not None:
+                    cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)
                 continue
 
             # De-identify the contact's urn.
@@ -157,5 +197,6 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, flow_r
             }
             _ensure_engagement_db_has_message(engagement_db, msg, message_origin_details)
 
+            # Update the cache so we know not to check this run again in this flow + result field context.
             if cache is not None:
-                cache.set_flow_last_updated(flow_id, flow_config.flow_result_field, flow_last_updated)
+                cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)

--- a/sync_rapid_pro_to_engagement_db.py
+++ b/sync_rapid_pro_to_engagement_db.py
@@ -12,6 +12,7 @@ log = Logger(__name__)
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Syncs data from a Rapid Pro workspace to an engagement database")
 
+    parser.add_argument("--incremental-cache-path")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
                         help="Path to a Google Cloud service account credentials file to use to access the "
@@ -22,6 +23,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    incremental_cache_path = args.incremental_cache_path
     user = args.user
     google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
     pipeline_config = importlib.import_module(args.configuration_module).PIPELINE_CONFIGURATION
@@ -43,5 +45,6 @@ if __name__ == "__main__":
         log.info(f"Syncing Rapid Pro source {i + 1}/{len(pipeline_config.rapid_pro_sources)}...")
         rapid_pro = rapid_pro_config.rapid_pro.init_rapid_pro_client(google_cloud_credentials_file_path)
 
-        sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_pro_config.flow_results, cache_path="cache")
+        sync_rapid_pro_to_engagement_db(
+            rapid_pro, engagement_db, uuid_table, rapid_pro_config.flow_results, incremental_cache_path)
 

--- a/sync_rapid_pro_to_engagement_db.py
+++ b/sync_rapid_pro_to_engagement_db.py
@@ -43,5 +43,5 @@ if __name__ == "__main__":
         log.info(f"Syncing Rapid Pro source {i + 1}/{len(pipeline_config.rapid_pro_sources)}...")
         rapid_pro = rapid_pro_config.rapid_pro.init_rapid_pro_client(google_cloud_credentials_file_path)
 
-        sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_pro_config.flow_results)
+        sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_pro_config.flow_results, cache_path="cache")
 


### PR DESCRIPTION
This works similarly to how the operations dashboard's sms service works - you can optionally pass a directory the script should use to cache results, so it only needs to download runs + contacts that changed since it last checked. Once dockerised, this would live in a docker volume and be reset simply by removing the volume.