### PR TITLE
Update engagement db -> Coda sync to fetch and write message by message

### DIFF
--- a/src/engagement_db_to_coda/engagement_db_to_coda.py
+++ b/src/engagement_db_to_coda/engagement_db_to_coda.py
@@ -1,4 +1,3 @@
-import core_data_modules.data_models
 from core_data_modules.cleaners.cleaning_utils import CleaningUtils
 from core_data_modules.data_models import Message as CodaMessage
 from core_data_modules.logging import Logger

--- a/src/engagement_db_to_coda/engagement_db_to_coda.py
+++ b/src/engagement_db_to_coda/engagement_db_to_coda.py
@@ -142,7 +142,7 @@ def _sync_next_message_to_coda(transaction, engagement_db, coda, coda_config, la
     Syncs a message from an engagement database to Coda.
 
     This method:
-     - Gets the least recently updated message that was last updated after `last_updated_since`.
+     - Gets the least recently updated message that was last updated after `last_seen_message`.
      - Writes back a coda id if the engagement db message doesn't have one yet.
      - Syncs the labels from Coda to this message if the message already exists in Coda.
      - Creates a new message in Coda if this message hasn't been seen in Coda yet.


### PR DESCRIPTION
Previously we fetched all the new documents, then updated them message by message. This removes the double-fetch read cost from that set-up, as well as laying the foundations for this to easily switch to incremental running. It will also now be really easy to batch these updates in future, simply by increasing the .limit()s and iterating over the fetched messages in _sync_next_message_to_coda