### PR TITLE
Standardise rapid_pro -> engagement_db config to have a sync_config argument

### DIFF
--- a/configurations/create_kenya_pool.py
+++ b/configurations/create_kenya_pool.py
@@ -1,16 +1,6 @@
-import json
-
 from core_data_modules.cleaners import swahili
-from core_data_modules.data_models import CodeScheme
 
-from src.common.configuration import RapidProClientConfiguration, CodaClientConfiguration, UUIDTableClientConfiguration, \
-    EngagementDatabaseClientConfiguration
-from src.engagement_db_coda_sync.configuration import CodaSyncConfiguration, CodaDatasetConfiguration, \
-    CodeSchemeConfiguration
-from src.engagement_db_to_rapid_pro.configuration import EngagementDBToRapidProConfiguration, DatasetConfiguration, \
-    WriteModes, ContactField
-from src.pipeline_configuration_spec import PipelineConfiguration, RapidProSource, CodaConfiguration, RapidProTarget
-from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
+from src.pipeline_configuration_spec import *
 
 
 def load_code_scheme(fname):
@@ -39,60 +29,70 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 domain="textit.com",
                 token_file_url="gs://avf-credentials/covid19-2-text-it-token.txt"
             ),
-            flow_results=[
-                FlowResultConfiguration("covid19_ke_urban_s01_demog", "constituency", "kenya_pool_location"),
-                FlowResultConfiguration("covid19_ke_urban_s01_demog", "gender", "kenya_pool_gender"),
-                FlowResultConfiguration("covid19_ke_urban_s01_demog", "age", "kenya_pool_age"),
+            sync_config=RapidProToEngagementDBConfiguration(
+                flow_result_configurations=[
+                    FlowResultConfiguration("covid19_ke_urban_s01_demog", "constituency", "kenya_pool_location"),
+                    FlowResultConfiguration("covid19_ke_urban_s01_demog", "gender", "kenya_pool_gender"),
+                    FlowResultConfiguration("covid19_ke_urban_s01_demog", "age", "kenya_pool_age"),
 
-                FlowResultConfiguration("undp_kenya_s01_demog", "constituency", "kenya_pool_location"),
-                FlowResultConfiguration("undp_kenya_s01_demog", "gender", "kenya_pool_gender"),
-                FlowResultConfiguration("undp_kenya_s01_demog", "age", "kenya_pool_age")
-            ]
+                    FlowResultConfiguration("undp_kenya_s01_demog", "constituency", "kenya_pool_location"),
+                    FlowResultConfiguration("undp_kenya_s01_demog", "gender", "kenya_pool_gender"),
+                    FlowResultConfiguration("undp_kenya_s01_demog", "age", "kenya_pool_age")
+                ]
+            )
         ),
         RapidProSource(
             rapid_pro=RapidProClientConfiguration(
                 domain="textit.com",
                 token_file_url="gs://avf-credentials/covid19-text-it-token.txt"
             ),
-            flow_results=[
-                FlowResultConfiguration("covid19_s01_demog", "constituency", "kenya_pool_location"),
-                FlowResultConfiguration("covid19_s01_demog", "gender", "kenya_pool_gender"),
-                FlowResultConfiguration("covid19_s01_demog", "age", "kenya_pool_age"),
-            ]
+            sync_config=RapidProToEngagementDBConfiguration(
+                flow_result_configurations=[
+                    FlowResultConfiguration("covid19_s01_demog", "constituency", "kenya_pool_location"),
+                    FlowResultConfiguration("covid19_s01_demog", "gender", "kenya_pool_gender"),
+                    FlowResultConfiguration("covid19_s01_demog", "age", "kenya_pool_age"),
+                ]
+            )
         ),
         RapidProSource(
             rapid_pro=RapidProClientConfiguration(
                 domain="textit.com",
                 token_file_url="gs://avf-credentials/unicef-kenya-textit-token.txt"
             ),
-            flow_results=[
-                FlowResultConfiguration("unicef_covid19_ke_s01_demog", "constituency", "kenya_pool_location"),
-                FlowResultConfiguration("unicef_covid19_ke_s01_demog", "gender", "kenya_pool_gender"),
-                FlowResultConfiguration("unicef_covid19_ke_s01_demog", "age", "kenya_pool_age"),
-            ]
+            sync_config=RapidProToEngagementDBConfiguration(
+                flow_result_configurations=[
+                    FlowResultConfiguration("unicef_covid19_ke_s01_demog", "constituency", "kenya_pool_location"),
+                    FlowResultConfiguration("unicef_covid19_ke_s01_demog", "gender", "kenya_pool_gender"),
+                    FlowResultConfiguration("unicef_covid19_ke_s01_demog", "age", "kenya_pool_age"),
+                ]
+            )
         ),
         RapidProSource(
             rapid_pro=RapidProClientConfiguration(
                 domain="textit.com",
                 token_file_url="gs://avf-credentials/oxfam-kenya-textit-token.txt"
             ),
-            flow_results=[
-                FlowResultConfiguration("oxfam_wash_s01_demog", "constituency", "kenya_pool_location"),
-                FlowResultConfiguration("oxfam_wash_s01_demog", "gender", "kenya_pool_gender"),
-                FlowResultConfiguration("oxfam_wash_s01_demog", "age", "kenya_pool_age"),
-                FlowResultConfiguration("oxfam_wash_s01_demog", "disabled", "kenya_pool_disabled"),
-            ]
+            sync_config=RapidProToEngagementDBConfiguration(
+                flow_result_configurations=[
+                    FlowResultConfiguration("oxfam_wash_s01_demog", "constituency", "kenya_pool_location"),
+                    FlowResultConfiguration("oxfam_wash_s01_demog", "gender", "kenya_pool_gender"),
+                    FlowResultConfiguration("oxfam_wash_s01_demog", "age", "kenya_pool_age"),
+                    FlowResultConfiguration("oxfam_wash_s01_demog", "disabled", "kenya_pool_disabled"),
+                ]
+            )
         ),
         RapidProSource(
             rapid_pro=RapidProClientConfiguration(
                 domain="textit.com",
                 token_file_url="gs://avf-credentials/world-vision-textit-token.txt"
             ),
-            flow_results=[
-                FlowResultConfiguration("worldvision_s01_demog", "constituency", "kenya_pool_location"),
-                FlowResultConfiguration("worldvision_s01_demog", "gender", "kenya_pool_gender"),
-                FlowResultConfiguration("worldvision_s01_demog", "age", "kenya_pool_age"),
-            ]
+            sync_config=RapidProToEngagementDBConfiguration(
+                flow_result_configurations=[
+                    FlowResultConfiguration("worldvision_s01_demog", "constituency", "kenya_pool_location"),
+                    FlowResultConfiguration("worldvision_s01_demog", "gender", "kenya_pool_gender"),
+                    FlowResultConfiguration("worldvision_s01_demog", "age", "kenya_pool_age"),
+                ]
+            )
         )
     ],
     coda_sync=CodaConfiguration(

--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -19,12 +19,14 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 domain="textit.com",
                 token_file_url="gs://avf-credentials/experimental-test-text-it-token.txt"
             ),
-            flow_results=[
-                FlowResultConfiguration("test_pipeline_daniel_activation", "rqa_s01e01", "s01e01"),
-                FlowResultConfiguration("test_pipeline_daniel_demog", "constituency", "location"),
-                FlowResultConfiguration("test_pipeline_daniel_demog", "age", "age"),
-                FlowResultConfiguration("test_pipeline_daniel_demog", "gender", "gender"),
-            ]
+            sync_config=RapidProToEngagementDBConfiguration(
+                flow_result_configurations=[
+                    FlowResultConfiguration("test_pipeline_daniel_activation", "rqa_s01e01", "s01e01"),
+                    FlowResultConfiguration("test_pipeline_daniel_demog", "constituency", "location"),
+                    FlowResultConfiguration("test_pipeline_daniel_demog", "age", "age"),
+                    FlowResultConfiguration("test_pipeline_daniel_demog", "gender", "gender"),
+                ]
+            )
         )
     ],
     coda_sync=CodaConfiguration(

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -9,7 +9,7 @@ from src.engagement_db_coda_sync.configuration import CodaSyncConfiguration, Cod
     CodeSchemeConfiguration
 from src.engagement_db_to_rapid_pro.configuration import EngagementDBToRapidProConfiguration, DatasetConfiguration, \
     WriteModes, ContactField
-from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration
+from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration, RapidProToEngagementDBConfiguration
 
 
 def load_code_scheme(fname):
@@ -20,7 +20,7 @@ def load_code_scheme(fname):
 @dataclass
 class RapidProSource:
     rapid_pro: RapidProClientConfiguration
-    flow_results: [FlowResultConfiguration]
+    sync_config: RapidProToEngagementDBConfiguration
 
 
 @dataclass

--- a/src/rapid_pro_to_engagement_db/configuration.py
+++ b/src/rapid_pro_to_engagement_db/configuration.py
@@ -6,3 +6,8 @@ class FlowResultConfiguration:
     flow_name: str
     flow_result_field: str
     engagement_db_dataset: str
+
+
+@dataclass
+class RapidProToEngagementDBConfiguration:
+    flow_result_configurations: [FlowResultConfiguration]

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -128,7 +128,7 @@ def _ensure_engagement_db_has_message(engagement_db, message, message_origin_det
     )
 
 
-def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, flow_result_configs, cache_path=None):
+def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_pro_config, cache_path=None):
     """
     Synchronises runs from a Rapid Pro workspace to an engagement database.
 
@@ -138,8 +138,8 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, flow_r
     :type engagement_db: engagement_database.EngagementDatabase
     :param uuid_table: UUID table to use to de-identify contact urns.
     :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
-    :param flow_result_configs: Configuration for data to sync.
-    :type flow_result_configs: list of rapid_pro_to_engagement_db.FlowResultConfiguration
+    :param rapid_pro_config: Configuration for the sync.
+    :type rapid_pro_config: src.rapid_pro_to_engagement_db.configuration.RapidProToEngagementDBConfiguration
     :param cache_path: Path to a directory to use to cache results needed for incremental operation.
                        If None, runs in non-incremental mode
     :type cache_path: str | None
@@ -161,7 +161,7 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, flow_r
     # (If the cache or a contacts file for this workspace don't exist, `contacts` will be `None` for now)
     contacts = _get_contacts_from_cache(cache)
 
-    for flow_config in flow_result_configs:
+    for flow_config in rapid_pro_config.flow_result_configurations:
         # Get the latest runs for this flow.
         flow_id = rapid_pro.get_flow_id(flow_config.flow_name)
         runs = _get_new_runs(rapid_pro, flow_id, flow_config.flow_result_field, cache)

--- a/sync_rapid_pro_to_engagement_db.py
+++ b/sync_rapid_pro_to_engagement_db.py
@@ -47,5 +47,5 @@ if __name__ == "__main__":
         rapid_pro = rapid_pro_config.rapid_pro.init_rapid_pro_client(google_cloud_credentials_file_path)
 
         sync_rapid_pro_to_engagement_db(
-            rapid_pro, engagement_db, uuid_table, rapid_pro_config.flow_results, incremental_cache_path)
+            rapid_pro, engagement_db, uuid_table, rapid_pro_config.sync_config, incremental_cache_path)
 


### PR DESCRIPTION
This harmonises the configuration with the format used for the other sync stages, and makes it easier to add additional configuration for the stage in future