### PR TITLE
Add incremental mode to the coda -> engagement db sync

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,9 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "message-last-updated"}
+CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "master"}
 RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "master"}
-CodaV2PythonClient = {editable = true,git = "https://www.github.com/AfricasVoices/CodaV2PythonClient",ref = "v0.1.0"}
+CodaV2PythonClient = {editable = true,git = "https://www.github.com/AfricasVoices/CodaV2PythonClient",ref = "main"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "master"}
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "master"}
+CoreDataModules = {editable = true,git = "https://www.github.com/AfricasVoices/CoreDataModules",ref = "message-last-updated"}
 RapidProTools = {editable = true,git = "https://www.github.com/AfricasVoices/RapidProTools",ref = "master"}
 CodaV2PythonClient = {editable = true,git = "https://www.github.com/AfricasVoices/CodaV2PythonClient",ref = "v0.1.0"}
 PipelineInfrastructure = {editable = true,git = "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",ref = "master"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -101,12 +101,12 @@
         "codav2pythonclient": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/CodaV2PythonClient",
-            "ref": "bd2f52e69a43ab1a523dd177c78ef1a0d0ac1ccc"
+            "ref": "c59797196d66ffb0c6dac754cd56426ff0ac8def"
         },
         "coredatamodules": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/CoreDataModules",
-            "ref": "dfa6b52af748bbb232424c3ee524d7a3ec3c454f"
+            "ref": "8d8ecfd265d164b27a0af64c69a85e589216cbce"
         },
         "firebase-admin": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fa719ebb9a3ef92129d34104078af16e85f60f04b8c49fd13bcc361e44c8340d"
+            "sha256": "992593c4f9c9a7b6103320be490d25f82788be89507b0d89746add8309adbcf5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,6 +21,7 @@
                 "sha256:10d056fa27f8563a271b345207402a6dcce8efab7e5b377e270329c62471b10d",
                 "sha256:be9aa45477a134aee56c8fac518627e1154df063e85f67d4f83ce0ccc23688e8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.12.6"
         },
         "cachetools": {
@@ -28,6 +29,7 @@
                 "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001",
                 "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"
             ],
+            "markers": "python_version ~= '3.5'",
             "version": "==4.2.2"
         },
         "certifi": {
@@ -96,23 +98,25 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "codav2pythonclient": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/CodaV2PythonClient",
-            "ref": "c59797196d66ffb0c6dac754cd56426ff0ac8def"
+            "ref": "84ad822d37a004823ce042b6c915981da51fa9a0"
         },
         "coredatamodules": {
             "editable": true,
-            "git": "https://www.github.com/AfricasVoices/CoreDataModules",
-            "ref": "8d8ecfd265d164b27a0af64c69a85e589216cbce"
+            "git": "https://github.com/AfricasVoices/CoreDataModules",
+            "ref": "69a851e2229672b07d6c9eeaf2e30aab243035c9"
         },
         "firebase-admin": {
             "hashes": [
                 "sha256:4df619b1b202985514b9a666f62ecb4c20211e89db833bb51916b31b4bb3db68",
                 "sha256:c753b32e4db1dabb8be336af3fbbce783001fa62dbe6da67b4061611ffd5cd4f"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==5.0.1"
         },
         "google-api-core": {
@@ -128,17 +132,19 @@
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:47479436c0d21062ce5646465aa90232b2a458514e8f27c1ddd226abd9f127af",
-                "sha256:c5d6049fc0a9224a024b513aac23179283831b0d8cd201384de93c078f585b51"
+                "sha256:a1db917a2fea66fbbb127891b7c740388bf166ee40d7db3bce0f0e78c4c22afb",
+                "sha256:a5d203241a93201a770c966f8eca39de7f88b28194f9d252065b18e83bd99c4b"
             ],
-            "version": "==2.11.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.12.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:b3a67fa9ba5b768861dacf374c2135eb09fa14a0e40c851c3b8ea7abe6fc8fef",
-                "sha256:e34e5f5de5610b202f9b40ebd9f8b27571d5c5537db9afed3a72b2db5a345039"
+                "sha256:9266252e11393943410354cf14a77bcca24dd2ccd9c4e1aef23034fe0fbae630",
+                "sha256:c7c215c74348ef24faef2f7b62f6d8e6b38824fe08b1e7b7b09a02d397eda7b3"
             ],
-            "version": "==1.32.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.32.1"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -152,6 +158,7 @@
                 "sha256:31e8c8596d3fbe2ecbe8708572b48741f8b247a78740aebfaf4da445487a1af5",
                 "sha256:3bd1e679a3d38b9da93c5919ae56239dda91fb32a2d954b2cd830392337c1cc9"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.7.1"
         },
         "google-cloud-firestore": {
@@ -164,10 +171,11 @@
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:89a5f5290e61990a5ae138d8ba8895bc3fe1e00fbc2e3b6beb7fb8378ca7a2f1",
-                "sha256:e9ba9e0486b385fa0b9f16a0c3bfa4cbb7001a2285adb65374de4415588cdb2d"
+                "sha256:560f7d112dce319a39b06c35cf53ae156ef42dfb213fc633c09aefaae7c060ec",
+                "sha256:620ce1a7369e109515d5cf4c6e783afcb321f2d3a14faff394c929e00f5a35ca"
             ],
-            "version": "==1.39.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.40.0"
         },
         "google-crc32c": {
             "hashes": [
@@ -209,6 +217,7 @@
                 "sha256:106db689574283a7d9d154d5a97ab384153c55a1195cecb8c01cad9e6e827628",
                 "sha256:1a1eb743d13f782d1405437c266b2c815ef13c2b141ba40835c74a3317539d01"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.3.1"
         },
         "googleapis-common-protos": {
@@ -216,6 +225,7 @@
                 "sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4",
                 "sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.53.0"
         },
         "grpcio": {
@@ -286,6 +296,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "iso8601": {
@@ -337,10 +348,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
-            "version": "==20.9"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
         },
         "pipelineinfrastructure": {
             "editable": true,
@@ -352,6 +364,7 @@
                 "sha256:ce6695ce804383ad6f392c4bb1874c323896290a1f656560de36416ba832d91e",
                 "sha256:df7c71c08dc06403bdb0fba58cf9bf5f217198f6488c26b768f81e03a738c059"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.19.0"
         },
         "protobuf": {
@@ -388,15 +401,37 @@
         },
         "pyasn1": {
             "hashes": [
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
                 "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
             ],
             "version": "==0.4.8"
         },
         "pyasn1-modules": {
             "hashes": [
+                "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8",
+                "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199",
+                "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811",
+                "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed",
+                "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4",
                 "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e",
-                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"
+                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74",
+                "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb",
+                "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45",
+                "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd",
+                "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0",
+                "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d",
+                "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
             ],
             "version": "==0.2.8"
         },
@@ -405,6 +440,7 @@
                 "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
                 "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.20"
         },
         "pyparsing": {
@@ -412,6 +448,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "python-dateutil": {
@@ -419,6 +456,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "pytz": {
@@ -433,6 +471,7 @@
                 "sha256:6f41f1a34bc2e8df7bcc54f29b5f1db8e50b1e95221ecf7ec040952e845b1b1e",
                 "sha256:cf69357a037d7dd6a487631f1350fe8fca73ce6ea0ae75f2c86ae22545261225"
             ],
+            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==2.8.3"
         },
         "rapidprotools": {
@@ -445,6 +484,7 @@
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
                 "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.25.1"
         },
         "rsa": {
@@ -460,6 +500,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "uritemplate": {
@@ -467,6 +508,7 @@
                 "sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f",
                 "sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.0.1"
         },
         "urllib3": {
@@ -474,6 +516,7 @@
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.6"
         }
     },

--- a/src/engagement_db_coda_sync/cache.py
+++ b/src/engagement_db_coda_sync/cache.py
@@ -45,3 +45,19 @@ class CodaSyncCache:
         IOUtils.ensure_dirs_exist_for_file(export_path)
         with open(export_path, "w") as f:
             f.write(self.message_to_json(message))
+
+    def _last_updated_timestamp_path(self, dataset):
+        return f"{self.cache_dir}/last-updated-timestamp-{dataset}.txt"
+
+    def get_last_updated_timestamp(self, dataset):
+        try:
+            with open(self._last_updated_timestamp_path(dataset)) as f:
+                return datetime.fromisoformat(f.read())
+        except FileNotFoundError:
+            return None
+
+    def set_last_updated_timestamp(self, dataset, last_updated_timestamp):
+        export_path = self._last_updated_timestamp_path(dataset)
+        IOUtils.ensure_dirs_exist_for_file(export_path)
+        with open(export_path, "w") as f:
+            f.write(last_updated_timestamp.isoformat())

--- a/src/engagement_db_coda_sync/coda_to_engagement_db.py
+++ b/src/engagement_db_coda_sync/coda_to_engagement_db.py
@@ -57,7 +57,6 @@ def sync_coda_to_engagement_db(coda, engagement_db, coda_config, cache_path=None
                        If None, runs in non-incremental mode.
     :type cache_path: str | None
     """
-    cache_path = "cache"
     if cache_path is None:
         cache = None
         log.warning(f"No `cache_path` provided. This tool will process all relevant Coda messages from all of time")

--- a/src/engagement_db_coda_sync/coda_to_engagement_db.py
+++ b/src/engagement_db_coda_sync/coda_to_engagement_db.py
@@ -2,6 +2,7 @@ from core_data_modules.logging import Logger
 from engagement_database.data_models import MessageStatuses
 from google.cloud import firestore
 
+from src.engagement_db_coda_sync.cache import CodaSyncCache
 from src.engagement_db_coda_sync.lib import _update_engagement_db_message_from_coda_message
 
 log = Logger(__name__)
@@ -42,7 +43,7 @@ def _sync_coda_message_to_engagement_db(transaction, coda_message, engagement_db
             engagement_db, engagement_db_message, coda_message, coda_config, transaction=transaction)
 
 
-def sync_coda_to_engagement_db(coda, engagement_db, coda_config):
+def sync_coda_to_engagement_db(coda, engagement_db, coda_config, cache_path=None):
     """
     Syncs messages from Coda to an engagement database.
 
@@ -52,11 +53,23 @@ def sync_coda_to_engagement_db(coda, engagement_db, coda_config):
     :type engagement_db: engagement_database.EngagementDatabase
     :param coda_config: Coda sync configuration.
     :type coda_config: src.engagement_db_coda_sync.configuration.CodaSyncConfiguration
+    :param cache_path: Path to a directory to use to cache results needed for incremental operation.
+                       If None, runs in non-incremental mode.
+    :type cache_path: str | None
     """
+    cache_path = "cache"
+    if cache_path is None:
+        cache = None
+        log.warning(f"No `cache_path` provided. This tool will process all relevant Coda messages from all of time")
+    else:
+        cache = CodaSyncCache(cache_path)
+
     for coda_dataset_config in coda_config.dataset_configurations:
         log.info(f"Getting messages from Coda dataset {coda_dataset_config.coda_dataset_id}...")
-        # TODO: Run incrementally.
-        coda_messages = coda.get_dataset_messages(coda_dataset_config.coda_dataset_id)
+        coda_messages = coda.get_dataset_messages(
+            coda_dataset_config.coda_dataset_id,
+            last_updated_after=None if cache is None else cache.get_last_updated_timestamp(coda_dataset_config.coda_dataset_id)
+        )
 
         for i, coda_message in enumerate(coda_messages):
             log.info(f"Processing Coda message {i + 1}/{len(coda_messages)}: {coda_message.message_id}...")
@@ -64,3 +77,8 @@ def sync_coda_to_engagement_db(coda, engagement_db, coda_config):
                 engagement_db.transaction(), coda_message, engagement_db, coda_dataset_config.engagement_db_dataset,
                 coda_config
             )
+
+        seen_timestamps = [msg.last_updated for msg in coda_messages if msg.last_updated is not None]
+        if cache is not None and len(seen_timestamps) > 0:
+            most_recently_updated_timestamp = sorted(seen_timestamps)[-1]
+            cache.set_last_updated_timestamp(coda_dataset_config.coda_dataset_id, most_recently_updated_timestamp)

--- a/sync_coda_to_engagement_db.py
+++ b/sync_coda_to_engagement_db.py
@@ -12,6 +12,8 @@ log = Logger(__name__)
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Syncs data from Coda to an engagement database")
 
+    parser.add_argument("--incremental-cache-path",
+                        help="Path to a directory to use to cache results needed for incremental operation.")
     parser.add_argument("user", help="Identifier of the user launching this program")
     parser.add_argument("google_cloud_credentials_file_path", metavar="google-cloud-credentials-file-path",
                         help="Path to a Google Cloud service account credentials file to use to access the "
@@ -22,6 +24,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    incremental_cache_path = args.incremental_cache_path
     user = args.user
     google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
     pipeline_config = importlib.import_module(args.configuration_module).PIPELINE_CONFIGURATION
@@ -40,4 +43,4 @@ if __name__ == "__main__":
     engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
     coda = pipeline_config.coda_sync.coda.init_coda_client(google_cloud_credentials_file_path)
 
-    sync_coda_to_engagement_db(coda, engagement_db, pipeline_config.coda_sync.sync_config)
+    sync_coda_to_engagement_db(coda, engagement_db, pipeline_config.coda_sync.sync_config, incremental_cache_path)


### PR DESCRIPTION
Note this fetches and processes all changed messages, which makes it more expensive under failures than the engagement db -> coda sync (which syncs one-by-one). However, solving this is very difficult while Coda has segments so suggest we live with this for now.