### PR TITLE
Add uuid_filter to rapid pro sync

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -41,57 +41,53 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813",
-                "sha256:04c468b622ed31d408fea2346bec5bbffba2cc44226302a0de1ade9f5ea3d373",
-                "sha256:06d7cd1abac2ffd92e65c0609661866709b4b2d82dd15f611e602b9b188b0b69",
-                "sha256:06db6321b7a68b2bd6df96d08a5adadc1fa0e8f419226e25b2a5fbf6ccc7350f",
-                "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06",
-                "sha256:0f861a89e0043afec2a51fd177a567005847973be86f709bbb044d7f42fc4e05",
-                "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea",
-                "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee",
-                "sha256:1bf1ac1984eaa7675ca8d5745a8cb87ef7abecb5592178406e55858d411eadc0",
-                "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396",
-                "sha256:24a570cd11895b60829e941f2613a4f79df1a27344cbbb82164ef2e0116f09c7",
-                "sha256:24ec4ff2c5c0c8f9c6b87d5bb53555bf267e1e6f70e52e5a9740d32861d36b6f",
-                "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73",
-                "sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315",
-                "sha256:293e7ea41280cb28c6fcaaa0b1aa1f533b8ce060b9e701d78511e1e6c4a1de76",
-                "sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1",
-                "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49",
-                "sha256:3c3f39fa737542161d8b0d680df2ec249334cd70a8f420f71c9304bd83c3cbed",
-                "sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892",
-                "sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482",
-                "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058",
-                "sha256:51182f8927c5af975fece87b1b369f722c570fe169f9880764b1ee3bca8347b5",
-                "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53",
-                "sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045",
-                "sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3",
-                "sha256:681d07b0d1e3c462dd15585ef5e33cb021321588bebd910124ef4f4fb71aef55",
-                "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5",
-                "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e",
-                "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c",
-                "sha256:72d8d3ef52c208ee1c7b2e341f7d71c6fd3157138abf1a95166e6165dd5d4369",
-                "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827",
-                "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053",
-                "sha256:99cd03ae7988a93dd00bcd9d0b75e1f6c426063d6f03d2f90b89e29b25b82dfa",
-                "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4",
-                "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322",
-                "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132",
-                "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62",
-                "sha256:a465da611f6fa124963b91bf432d960a555563efe4ed1cc403ba5077b15370aa",
-                "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0",
-                "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396",
-                "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e",
-                "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991",
-                "sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6",
-                "sha256:cc5a8e069b9ebfa22e26d0e6b97d6f9781302fe7f4f2b8776c3e1daea35f1adc",
-                "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1",
-                "sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406",
-                "sha256:df5052c5d867c1ea0b311fb7c3cd28b19df469c056f7fdcfe88c7473aa63e333",
-                "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d",
-                "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"
+                "sha256:06c54a68935738d206570b20da5ef2b6b6d92b38ef3ec45c5422c0ebaf338d4d",
+                "sha256:0c0591bee64e438883b0c92a7bed78f6290d40bf02e54c5bf0978eaf36061771",
+                "sha256:19ca0dbdeda3b2615421d54bef8985f72af6e0c47082a8d26122adac81a95872",
+                "sha256:22b9c3c320171c108e903d61a3723b51e37aaa8c81255b5e7ce102775bd01e2c",
+                "sha256:26bb2549b72708c833f5abe62b756176022a7b9a7f689b571e74c8478ead51dc",
+                "sha256:33791e8a2dc2953f28b8d8d300dde42dd929ac28f974c4b4c6272cb2955cb762",
+                "sha256:3c8d896becff2fa653dc4438b54a5a25a971d1f4110b32bd3068db3722c80202",
+                "sha256:4373612d59c404baeb7cbd788a18b2b2a8331abcc84c3ba40051fcd18b17a4d5",
+                "sha256:487d63e1454627c8e47dd230025780e91869cfba4c753a74fda196a1f6ad6548",
+                "sha256:48916e459c54c4a70e52745639f1db524542140433599e13911b2f329834276a",
+                "sha256:4922cd707b25e623b902c86188aca466d3620892db76c0bdd7b99a3d5e61d35f",
+                "sha256:55af55e32ae468e9946f741a5d51f9896da6b9bf0bbdd326843fec05c730eb20",
+                "sha256:57e555a9feb4a8460415f1aac331a2dc833b1115284f7ded7278b54afc5bd218",
+                "sha256:5d4b68e216fc65e9fe4f524c177b54964af043dde734807586cf5435af84045c",
+                "sha256:64fda793737bc4037521d4899be780534b9aea552eb673b9833b01f945904c2e",
+                "sha256:6d6169cb3c6c2ad50db5b868db6491a790300ade1ed5d1da29289d73bbe40b56",
+                "sha256:7bcac9a2b4fdbed2c16fa5681356d7121ecabf041f18d97ed5b8e0dd38a80224",
+                "sha256:80b06212075346b5546b0417b9f2bf467fea3bfe7352f781ffc05a8ab24ba14a",
+                "sha256:818014c754cd3dba7229c0f5884396264d51ffb87ec86e927ef0be140bfdb0d2",
+                "sha256:8eb687582ed7cd8c4bdbff3df6c0da443eb89c3c72e6e5dcdd9c81729712791a",
+                "sha256:99f27fefe34c37ba9875f224a8f36e31d744d8083e00f520f133cab79ad5e819",
+                "sha256:9f3e33c28cd39d1b655ed1ba7247133b6f7fc16fa16887b120c0c670e35ce346",
+                "sha256:a8661b2ce9694ca01c529bfa204dbb144b275a31685a075ce123f12331be790b",
+                "sha256:a9da7010cec5a12193d1af9872a00888f396aba3dc79186604a09ea3ee7c029e",
+                "sha256:aedb15f0a5a5949ecb129a82b72b19df97bbbca024081ed2ef88bd5c0a610534",
+                "sha256:b315d709717a99f4b27b59b021e6207c64620790ca3e0bde636a6c7f14618abb",
+                "sha256:ba6f2b3f452e150945d58f4badd92310449876c4c954836cfb1803bdd7b422f0",
+                "sha256:c33d18eb6e6bc36f09d793c0dc58b0211fccc6ae5149b808da4a62660678b156",
+                "sha256:c9a875ce9d7fe32887784274dd533c57909b7b1dcadcc128a2ac21331a9765dd",
+                "sha256:c9e005e9bd57bc987764c32a1bee4364c44fdc11a3cc20a40b93b444984f2b87",
+                "sha256:d2ad4d668a5c0645d281dcd17aff2be3212bc109b33814bbb15c4939f44181cc",
+                "sha256:d950695ae4381ecd856bcaf2b1e866720e4ab9a1498cba61c602e56630ca7195",
+                "sha256:e22dcb48709fc51a7b58a927391b23ab37eb3737a98ac4338e2448bef8559b33",
+                "sha256:e8c6a99be100371dbb046880e7a282152aa5d6127ae01783e37662ef73850d8f",
+                "sha256:e9dc245e3ac69c92ee4c167fbdd7428ec1956d4e754223124991ef29eb57a09d",
+                "sha256:eb687a11f0a7a1839719edd80f41e459cc5366857ecbed383ff376c4e3cc6afd",
+                "sha256:eb9e2a346c5238a30a746893f23a9535e700f8192a68c07c0258e7ece6ff3728",
+                "sha256:ed38b924ce794e505647f7c331b22a693bee1538fdf46b0222c4717b42f744e7",
+                "sha256:f0010c6f9d1a4011e429109fda55a225921e3206e7f62a0c22a35344bfd13cca",
+                "sha256:f0c5d1acbfca6ebdd6b1e3eded8d261affb6ddcf2186205518f1428b8569bb99",
+                "sha256:f10afb1004f102c7868ebfe91c28f4a712227fe4cb24974350ace1f90e1febbf",
+                "sha256:f174135f5609428cc6e1b9090f9268f5c8935fddb1b25ccb8255a2d50de6789e",
+                "sha256:f3ebe6e73c319340830a9b2825d32eb6d8475c1dac020b4f0aa774ee3b898d1c",
+                "sha256:f627688813d0a4140153ff532537fbe4afea5a3dffce1f9deb7f91f848a832b5",
+                "sha256:fd4305f86f53dfd8cd3522269ed7fc34856a8ee3709a5e28b2836b2db9d4cd69"
             ],
-            "version": "==1.14.5"
+            "version": "==1.14.6"
         },
         "chardet": {
             "hashes": [
@@ -124,19 +120,19 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:0724d354d394b3d763bc10dfee05807813c5210f0bd9b8e2ddf6b6925603411c",
-                "sha256:92cd9e9f366e84bfcf2524e34d2dc244906c645e731962617ba620da1620a1e0"
+                "sha256:7c8ba88e2b893ef4f67d67e229aade51a2db5053023b73b1394a5ee3dcdb561c",
+                "sha256:a9f979b5c6a9cad31a4120ca6be712df76adc32336a7bf4bc2f4331a1b527fe7"
             ],
             "markers": "platform_python_implementation != 'PyPy'",
-            "version": "==1.30.0"
+            "version": "==1.31.0"
         },
         "google-api-python-client": {
             "hashes": [
-                "sha256:a1db917a2fea66fbbb127891b7c740388bf166ee40d7db3bce0f0e78c4c22afb",
-                "sha256:a5d203241a93201a770c966f8eca39de7f88b28194f9d252065b18e83bd99c4b"
+                "sha256:345bb7249ac9af93a6c75e4adb93a41139459945aee61e611a5c8e5b146cbef7",
+                "sha256:b3874333cabc5ce46dcda2da48f1b258e227a9ae61688211e277e11270386307"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.12.0"
+            "version": "==2.13.0"
         },
         "google-auth": {
             "hashes": [
@@ -357,7 +353,7 @@
         "pipelineinfrastructure": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",
-            "ref": "cb646f7a4465705351b7828d0bf20bfab1ba193b"
+            "ref": "53e6f7842ee47b70becf2c15c45fc0ba82e7f712"
         },
         "proto-plus": {
             "hashes": [
@@ -477,7 +473,7 @@
         "rapidprotools": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/RapidProTools",
-            "ref": "553ae92c0d6a319a325ba8fe45fbc0b335b2d884"
+            "ref": "3ae29d4acf429e160736891806ff19d876f52627"
         },
         "requests": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -357,7 +357,7 @@
         "pipelineinfrastructure": {
             "editable": true,
             "git": "https://www.github.com/AfricasVoices/Pipeline-Infrastructure",
-            "ref": "a0b523f1b888bd2ab298bf9284a1974ca7728079"
+            "ref": "cb646f7a4465705351b7828d0bf20bfab1ba193b"
         },
         "proto-plus": {
             "hashes": [

--- a/configurations/create_kenya_pool.py
+++ b/configurations/create_kenya_pool.py
@@ -8,6 +8,10 @@ def load_code_scheme(fname):
         return CodeScheme.from_firebase_map(json.load(f))
 
 
+# TODO: Regenerate this file based on the latest Kenya pool opt-ins before entering production.
+rapid_pro_uuid_filter = UuidFilter(uuid_file_url="gs://avf-project-datasets/Test/2021/Kenya-Pool/opt_in_uuids.json")
+
+
 # TODO: Add GPSDD to pool
 PIPELINE_CONFIGURATION = PipelineConfiguration(
     pipeline_name="Create-Kenya-Pool",
@@ -38,7 +42,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                     FlowResultConfiguration("undp_kenya_s01_demog", "constituency", "kenya_pool_location"),
                     FlowResultConfiguration("undp_kenya_s01_demog", "gender", "kenya_pool_gender"),
                     FlowResultConfiguration("undp_kenya_s01_demog", "age", "kenya_pool_age")
-                ]
+                ],
+                uuid_filter=rapid_pro_uuid_filter
             )
         ),
         RapidProSource(

--- a/configurations/create_kenya_pool.py
+++ b/configurations/create_kenya_pool.py
@@ -56,7 +56,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                     FlowResultConfiguration("covid19_s01_demog", "constituency", "kenya_pool_location"),
                     FlowResultConfiguration("covid19_s01_demog", "gender", "kenya_pool_gender"),
                     FlowResultConfiguration("covid19_s01_demog", "age", "kenya_pool_age"),
-                ]
+                ],
+                uuid_filter=rapid_pro_uuid_filter
             )
         ),
         RapidProSource(
@@ -69,7 +70,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                     FlowResultConfiguration("unicef_covid19_ke_s01_demog", "constituency", "kenya_pool_location"),
                     FlowResultConfiguration("unicef_covid19_ke_s01_demog", "gender", "kenya_pool_gender"),
                     FlowResultConfiguration("unicef_covid19_ke_s01_demog", "age", "kenya_pool_age"),
-                ]
+                ],
+                uuid_filter=rapid_pro_uuid_filter
             )
         ),
         RapidProSource(
@@ -83,7 +85,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                     FlowResultConfiguration("oxfam_wash_s01_demog", "gender", "kenya_pool_gender"),
                     FlowResultConfiguration("oxfam_wash_s01_demog", "age", "kenya_pool_age"),
                     FlowResultConfiguration("oxfam_wash_s01_demog", "disabled", "kenya_pool_disabled"),
-                ]
+                ],
+                uuid_filter=rapid_pro_uuid_filter
             )
         ),
         RapidProSource(
@@ -96,7 +99,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                     FlowResultConfiguration("worldvision_s01_demog", "constituency", "kenya_pool_location"),
                     FlowResultConfiguration("worldvision_s01_demog", "gender", "kenya_pool_gender"),
                     FlowResultConfiguration("worldvision_s01_demog", "age", "kenya_pool_age"),
-                ]
+                ],
+                uuid_filter=rapid_pro_uuid_filter
             )
         )
     ],

--- a/configurations/create_kenya_pool.py
+++ b/configurations/create_kenya_pool.py
@@ -108,14 +108,14 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
         coda=CodaClientConfiguration(credentials_file_url="gs://avf-credentials/coda-staging.json"),
         sync_config=CodaSyncConfiguration(
             dataset_configurations=[
-                CodaDatasetConfiguration(
-                    coda_dataset_id="Kenya_Pool_disabled",
-                    engagement_db_dataset="kenya_pool_disabled",
-                    code_scheme_configurations=[
-                        CodeSchemeConfiguration(code_scheme=load_code_scheme("disabled"), auto_coder=None)  # TODO
-                    ],
-                    ws_code_string_value="disabled"
-                ),
+                # CodaDatasetConfiguration(
+                #     coda_dataset_id="Kenya_Pool_disabled",
+                #     engagement_db_dataset="kenya_pool_disabled",
+                #     code_scheme_configurations=[
+                #         CodeSchemeConfiguration(code_scheme=load_code_scheme("disabled"), auto_coder=None)  # TODO
+                #     ],
+                #     ws_code_string_value="disabled"
+                # ),
                 CodaDatasetConfiguration(
                     coda_dataset_id="TEST_location",
                     engagement_db_dataset="location",
@@ -125,22 +125,22 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                     ],
                     ws_code_string_value="location"
                 ),
-                CodaDatasetConfiguration(
-                    coda_dataset_id="Kenya_Pool_gender",
-                    engagement_db_dataset="kenya_pool_gender",
-                    code_scheme_configurations=[
-                        CodeSchemeConfiguration(code_scheme=load_code_scheme("gender"), auto_coder=swahili.DemographicCleaner.clean_gender)
-                    ],
-                    ws_code_string_value="gender"
-                ),
-                CodaDatasetConfiguration(
-                    coda_dataset_id="Kenya_Pool_age",
-                    engagement_db_dataset="kenya_pool_age",
-                    code_scheme_configurations=[
-                        # CodeSchemeConfiguration(code_scheme=load_code_scheme("age"), auto_coder=None)  # TODO
-                    ],
-                    ws_code_string_value="age"
-                )
+                # CodaDatasetConfiguration(
+                #     coda_dataset_id="Kenya_Pool_gender",
+                #     engagement_db_dataset="kenya_pool_gender",
+                #     code_scheme_configurations=[
+                #         CodeSchemeConfiguration(code_scheme=load_code_scheme("gender"), auto_coder=swahili.DemographicCleaner.clean_gender)
+                #     ],
+                #     ws_code_string_value="gender"
+                # ),
+                # CodaDatasetConfiguration(
+                #     coda_dataset_id="Kenya_Pool_age",
+                #     engagement_db_dataset="kenya_pool_age",
+                #     code_scheme_configurations=[
+                #         # CodeSchemeConfiguration(code_scheme=load_code_scheme("age"), auto_coder=None)  # TODO
+                #     ],
+                #     ws_code_string_value="age"
+                # )
             ],
             ws_correct_dataset_code_scheme=load_code_scheme("ws_correct_dataset")
         )

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -10,7 +10,8 @@ from src.engagement_db_coda_sync.configuration import (CodaSyncConfiguration, Co
                                                        CodeSchemeConfiguration)
 from src.engagement_db_to_rapid_pro.configuration import (EngagementDBToRapidProConfiguration, DatasetConfiguration,
                                                           WriteModes, ContactField)
-from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration, RapidProToEngagementDBConfiguration
+from src.rapid_pro_to_engagement_db.configuration import FlowResultConfiguration, UuidFilter, \
+    RapidProToEngagementDBConfiguration
 from src.engagement_db_to_analysis.configuration import AnalysisDatasetConfiguration, DatasetTypes
 
 

--- a/src/rapid_pro_to_engagement_db/configuration.py
+++ b/src/rapid_pro_to_engagement_db/configuration.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -9,5 +10,11 @@ class FlowResultConfiguration:
 
 
 @dataclass
+class UuidFilter:
+    uuid_file_url: str
+
+
+@dataclass
 class RapidProToEngagementDBConfiguration:
     flow_result_configurations: [FlowResultConfiguration]
+    uuid_filter: Optional[UuidFilter] = None

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -1,7 +1,6 @@
 import json
 from datetime import timedelta
 
-import storage.google_cloud.google_cloud_utils
 from core_data_modules.cleaners import URNCleaner
 from core_data_modules.logging import Logger
 from engagement_database.data_models import Message, MessageDirections, MessageStatuses, HistoryEntryOrigin

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -207,8 +207,15 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
                 # If a uuid filter exists, then only add this message if the sender's uuid exists in the uuid table
                 # and in the valid uuids. The check for presence in the uuid table is to ensure we don't add a uuid
                 # table entry for people who didn't consent for us to continue to keep their data.
-                if not uuid_table.has_data(contact_urn) or uuid_table.data_to_uuid(contact_urn) not in valid_participant_uuids:
-                    log.info("Message not from a participant uuid specified in the uuid filter; skipping")
+                if not uuid_table.has_data(contact_urn):
+                    log.info("A uuid filter was specified and the message is not from a participant in the "
+                             "uuid_table; skipping")
+                    if cache is not None:
+                        cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)
+                    continue
+                if uuid_table.data_to_uuid(contact_urn) not in valid_participant_uuids:
+                    log.info("A uuid filter was specified and the message is from a participant in the "
+                             "uuid_table but is not in the uuid filter; skipping")
                     if cache is not None:
                         cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)
                     continue

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -209,6 +209,8 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
                 # table entry for people who didn't consent for us to continue to keep their data.
                 if not uuid_table.has_data(contact_urn) or uuid_table.data_to_uuid(contact_urn) not in valid_participant_uuids:
                     log.info("Message not from a participant uuid in specified in the uuid filter; skipping")
+                    if cache is not None:
+                        cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)
                     continue
 
             participant_uuid = uuid_table.data_to_uuid(contact_urn)

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -208,7 +208,7 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
                 # and in the valid uuids. The check for presence in the uuid table is to ensure we don't add a uuid
                 # table entry for people who didn't consent for us to continue to keep their data.
                 if not uuid_table.has_data(contact_urn):
-                    log.info("A uuid filter was specified and the message is not from a participant in the "
+                    log.info("A uuid filter was specified but the message is not from a participant in the "
                              "uuid_table; skipping")
                     if cache is not None:
                         cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -208,7 +208,7 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
                 # and in the valid uuids. The check for presence in the uuid table is to ensure we don't add a uuid
                 # table entry for people who didn't consent for us to continue to keep their data.
                 if not uuid_table.has_data(contact_urn) or uuid_table.data_to_uuid(contact_urn) not in valid_participant_uuids:
-                    log.info("Message not from a participant uuid in specified in the uuid filter; skipping")
+                    log.info("Message not from a participant uuid specified in the uuid filter; skipping")
                     if cache is not None:
                         cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)
                     continue

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -1,8 +1,11 @@
+import json
 from datetime import timedelta
 
+import storage.google_cloud.google_cloud_utils
 from core_data_modules.cleaners import URNCleaner
 from core_data_modules.logging import Logger
 from engagement_database.data_models import Message, MessageDirections, MessageStatuses, HistoryEntryOrigin
+from storage.google_cloud import google_cloud_utils
 
 from src.rapid_pro_to_engagement_db.cache import RapidProSyncCache
 
@@ -53,14 +56,14 @@ def _get_new_runs(rapid_pro, flow_id, flow_result_field, cache=None):
     return rapid_pro.get_raw_runs(flow_id, last_modified_after_inclusive=filter_last_modified_after)
 
 
-def _de_identify_contact_urn(contact_urn, uuid_table):
+def _normalise_and_validate_contact_urn(contact_urn):
     """
-    De-identifies the given URN using the given uuid_table.
+    Normalises and validates the given URN.
+
+    Fails with an AssertionError if the given URN is invalid.
 
     :param contact_urn: URN to de-identify.
     :type contact_urn: str
-    :param uuid_table: Uuid table to use to de-identify.
-    :type uuid_table: id_infrastructure.firestore_uuid_table.FirestoreUuidTable
     :return: De-identified urn.
     :rtype: str
     """
@@ -75,7 +78,7 @@ def _de_identify_contact_urn(contact_urn, uuid_table):
         # this #<username>
         contact_urn = contact_urn.split("#")[0]
 
-    return uuid_table.data_to_uuid(contact_urn)
+    return contact_urn
 
 
 def _engagement_db_has_message(engagement_db, message):
@@ -128,7 +131,7 @@ def _ensure_engagement_db_has_message(engagement_db, message, message_origin_det
     )
 
 
-def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_pro_config, cache_path=None):
+def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_pro_config, google_cloud_credentials_file_path, cache_path=None):
     """
     Synchronises runs from a Rapid Pro workspace to an engagement database.
 
@@ -149,6 +152,13 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
     # TODO: Handle deleted contacts.
     # TODO: Optimise fetching fields from the same flows, so we don't have to download the same runs multiple times.
     workspace_name = rapid_pro.get_workspace_name()
+
+    if rapid_pro_config.uuid_filter is not None:
+        valid_participant_uuids = set(json.loads(google_cloud_utils.download_blob_to_string(
+            google_cloud_credentials_file_path,
+            rapid_pro_config.uuid_filter.uuid_file_url
+        )))
+        log.info(f"Loaded {len(valid_participant_uuids)} valid contacts to filter for")
 
     if cache_path is not None:
         log.info(f"Initialising Rapid Pro sync cache at '{cache_path}/{workspace_name}'")
@@ -182,7 +192,7 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
             # Get the relevant result from this run, if it exists.
             rapid_pro_result = run.values.get(flow_config.flow_result_field)
             if rapid_pro_result is None:
-                log.debug("No relevant run result")
+                log.debug("No relevant run result; skipping")
                 # Update the cache so we know not to check this run again in this flow + result field context.
                 if cache is not None:
                     cache.set_latest_run_timestamp(flow_id, flow_config.flow_result_field, run.modified_on)
@@ -191,8 +201,17 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
             # De-identify the contact's full urn.
             contact = contacts_lut[run.contact.uuid]
             assert len(contact.urns) == 1, len(contact.urns)
-            contact_urn = contact.urns[0]
-            participant_uuid = _de_identify_contact_urn(contact_urn, uuid_table)
+            contact_urn = _normalise_and_validate_contact_urn(contact.urns[0])
+
+            if rapid_pro_config.uuid_filter is not None:
+                # If a uuid filter exists, then only add this message if the sender's uuid exists in the uuid table
+                # and in the valid uuids. The check for presence in the uuid table is to ensure we don't add a uuid
+                # table entry for people who didn't consent for us to continue to keep their data.
+                if not uuid_table.has_data(contact_urn) or uuid_table.data_to_uuid(contact_urn) not in valid_participant_uuids:
+                    log.info("Message not from a participant uuid in specified in the uuid filter; skipping")
+                    continue
+
+            participant_uuid = uuid_table.data_to_uuid(contact_urn)
 
             # Create a message and origin objects for this result and ensure it's in the engagement database.
             msg = Message(

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -64,7 +64,7 @@ def _normalise_and_validate_contact_urn(contact_urn):
 
     :param contact_urn: URN to de-identify.
     :type contact_urn: str
-    :return: De-identified urn.
+    :return: Normalised contact urn.
     :rtype: str
     """
     if contact_urn.startswith("tel:"):

--- a/sync_rapid_pro_to_engagement_db.py
+++ b/sync_rapid_pro_to_engagement_db.py
@@ -69,5 +69,6 @@ if __name__ == "__main__":
             rapid_pro = rapid_pro_config.rapid_pro.init_rapid_pro_client(google_cloud_credentials_file_path)
 
         sync_rapid_pro_to_engagement_db(
-            rapid_pro, engagement_db, uuid_table, rapid_pro_config.sync_config, incremental_cache_path)
-
+            rapid_pro, engagement_db, uuid_table, rapid_pro_config.sync_config, google_cloud_credentials_file_path,
+            incremental_cache_path
+        )


### PR DESCRIPTION
This lets us exclude participants that aren't in a pre-created file of valid participant uuids. This lets us build the Kenya pool without touching data from people who didn't opt-in. Once the pool is created and our db operations are stabilised, we probably won't need this anymore.