### PR TITLE
Add default ws_dataset

### DIFF
--- a/configurations/create_kenya_pool.py
+++ b/configurations/create_kenya_pool.py
@@ -142,7 +142,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                     ws_code_string_value="disabled"
                 ),
             ],
-            ws_correct_dataset_code_scheme=load_code_scheme("kenya_pool_ws_correct_dataset")
+            ws_correct_dataset_code_scheme=load_code_scheme("kenya_pool_ws_correct_dataset"),
+            default_ws_dataset="kenya_pool_rqa"  # These can be manually archived later.
         )
     ),
     rapid_pro_target=RapidProTarget(
@@ -155,9 +156,11 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 DatasetConfiguration(engagement_db_datasets=["kenya_pool_gender"],   rapid_pro_contact_field=ContactField(key="gender",   label="Gender")),
                 DatasetConfiguration(engagement_db_datasets=["kenya_pool_location"], rapid_pro_contact_field=ContactField(key="location", label="Location")),
                 DatasetConfiguration(engagement_db_datasets=["kenya_pool_age"],      rapid_pro_contact_field=ContactField(key="age",      label="Age")),
+                DatasetConfiguration(engagement_db_datasets=["kenya_pool_disabled"], rapid_pro_contact_field=ContactField(key="disabled", label="Disabled")),
             ],
             consent_withdrawn_dataset=DatasetConfiguration(
-                engagement_db_datasets=["kenya_pool_gender", "kenya_pool_location", "kenya_pool_age"],
+                engagement_db_datasets=["kenya_pool_gender", "kenya_pool_location", "kenya_pool_age",
+                                        "kenya_pool_disabled", "kenya_pool_rqa"],
                 rapid_pro_contact_field=ContactField(key="engagement_db_consent_withdrawn", label="Engagement DB Consent Withdrawn")
             ),
             write_mode=WriteModes.CONCATENATE_TEXTS

--- a/src/engagement_db_coda_sync/configuration.py
+++ b/src/engagement_db_coda_sync/configuration.py
@@ -22,6 +22,11 @@ class CodaDatasetConfiguration:
 class CodaSyncConfiguration:
     dataset_configurations: [CodaDatasetConfiguration]
     ws_correct_dataset_code_scheme: CodeScheme
+    default_ws_dataset: Optional[str] = None  # Engagement db dataset to move messages to if there is no dataset
+                                              # configuration for a particular ws_code_string_value. If None, crashes if
+                                              # a message is found with a WS label with a string value not in
+                                              # dataset_configurations. In most circumstances, this should be None as matching
+                                              # cases where there are no datasets usually indicates a missing piece of configuration.
 
     def get_dataset_config_by_engagement_db_dataset(self, dataset):
         for config in self.dataset_configurations:

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -104,7 +104,14 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
     for label in coda_message.get_latest_labels():
         if label.scheme_id == ws_scheme.scheme_id:
             ws_code = ws_scheme.get_code_with_code_id(label.code_id)
-            correct_dataset = coda_config.get_dataset_config_by_ws_code_string_value(ws_code.string_value).engagement_db_dataset
+            try:
+                correct_dataset = coda_config.get_dataset_config_by_ws_code_string_value(ws_code.string_value).engagement_db_dataset
+            except ValueError as e:
+                # No dataset configuration found with an appropriate ws_code_string_value to move the message to.
+                # Fallback to the default dataset if available, otherwise crash.
+                if coda_config.default_ws_dataset is None:
+                    raise e
+                correct_dataset = coda_config.default_ws_dataset
 
             # Ensure this message isn't being moved to a dataset which it has previously been assigned to.
             # This is because if the message has already been in this new dataset, there is a chance there is an


### PR DESCRIPTION
This lets us handle messages that are WS-corrected to a project rqa, by routing them all to a kenya_pool_rqa dataset. We can then archive these redirected messages later.