### PR TITLE
Cache data into sub-directories of cache_path

### DIFF
--- a/src/engagement_db_coda_sync/coda_to_engagement_db.py
+++ b/src/engagement_db_coda_sync/coda_to_engagement_db.py
@@ -61,7 +61,8 @@ def sync_coda_to_engagement_db(coda, engagement_db, coda_config, cache_path=None
         cache = None
         log.warning(f"No `cache_path` provided. This tool will process all relevant Coda messages from all of time")
     else:
-        cache = CodaSyncCache(cache_path)
+        log.info(f"Initialising Coda sync cache at '{cache_path}/coda_to_engagement_db'")
+        cache = CodaSyncCache(f"{cache_path}/coda_to_engagement_db")
 
     for coda_dataset_config in coda_config.dataset_configurations:
         log.info(f"Getting messages from Coda dataset {coda_dataset_config.coda_dataset_id}...")

--- a/src/engagement_db_coda_sync/engagement_db_to_coda.py
+++ b/src/engagement_db_coda_sync/engagement_db_to_coda.py
@@ -151,7 +151,8 @@ def sync_engagement_db_to_coda(engagement_db, coda, coda_config, cache_path=None
         cache = None
         log.warning(f"No `cache_path` provided. This tool will process all relevant messages from all of time")
     else:
-        cache = CodaSyncCache(cache_path)
+        log.info(f"Initialising Coda sync cache at '{cache_path}/engagement_db_to_coda'")
+        cache = CodaSyncCache(f"{cache_path}/engagement_db_to_coda")
 
     for dataset_config in coda_config.dataset_configurations:
         log.info(f"Syncing engagement db dataset {dataset_config.engagement_db_dataset} to Coda dataset "

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -35,8 +35,8 @@ def _get_project_messages_from_engagement_db(analysis_configurations, engagement
     :rtype: dict of str -> list of Message
     """
 
-    log.info(f"Initialising EngagementAnalysisCache at '{cache_path}'")
-    cache = AnalysisCache(cache_path)
+    log.info(f"Initialising EngagementAnalysisCache at '{cache_path}/engagement_db_to_analysis'")
+    cache = AnalysisCache(f"{cache_path}/engagement_db_to_analysis")
 
     engagement_db_dataset_messages_map = {}  # of engagement_db_dataset to list of messages
     for config in analysis_configurations:

--- a/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
+++ b/src/rapid_pro_to_engagement_db/rapid_pro_to_engagement_db.py
@@ -162,8 +162,8 @@ def sync_rapid_pro_to_engagement_db(rapid_pro, engagement_db, uuid_table, rapid_
         log.info(f"Loaded {len(valid_participant_uuids)} valid contacts to filter for")
 
     if cache_path is not None:
-        log.info(f"Initialising Rapid Pro sync cache at '{cache_path}/{workspace_name}'")
-        cache = RapidProSyncCache(f"{cache_path}/{workspace_name}")
+        log.info(f"Initialising Rapid Pro sync cache at '{cache_path}/rapid_pro_to_engagement_db/{workspace_name}'")
+        cache = RapidProSyncCache(f"{cache_path}/rapid_pro_to_engagement_db/{workspace_name}")
     else:
         log.warning("No `cache_path` provided. This tool will process all relevant runs from Rapid Pro from all of time")
         cache = None


### PR DESCRIPTION
This makes cache directories safer and easier to work with, because we no longer need to worry about manually creating a separate directory for each stage/the risks of any stage not working if it's sharing a directory with another stage's cache.