### PR TITLE
Log engagement db -> coda sync stats and summarise at end of run

### DIFF
--- a/src/engagement_db_coda_sync/engagement_db_to_coda.py
+++ b/src/engagement_db_coda_sync/engagement_db_to_coda.py
@@ -5,6 +5,7 @@ from google.cloud import firestore
 
 from src.engagement_db_coda_sync.cache import CodaSyncCache
 from src.engagement_db_coda_sync.lib import _update_engagement_db_message_from_coda_message, _add_message_to_coda
+from src.engagement_db_coda_sync.sync_stats import CodaSyncStats, CodaSyncEvents
 
 log = Logger(__name__)
 
@@ -34,9 +35,10 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
                               If provided, downloads the least recently updated (next) message after this one, otherwise
                               downloads the least recently updated message in the database.
     :type last_seen_message: engagement_database.data_models.Message | None
-    :return: The engagement database message that was synced.
-             If there was no new message to sync, returns None.
-    :rtype: engagement_database.data_models.Message | None
+    :return: A tuple of:
+             1. The engagement database message that was synced. If there was no new message to sync, returns None.
+             2. Sync stats for the next synced message.
+    :rtype: (engagement_database.data_models.Message | None, src.engagement_db_coda_sync.sync_stats.CodaSyncStats)
     """
     if last_seen_message is None:
         messages_filter = lambda q: q \
@@ -58,16 +60,19 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
 
     next_message_results = engagement_db.get_messages(filter=messages_filter, transaction=transaction)
 
+    sync_stats = CodaSyncStats()
     if len(next_message_results) == 0:
-        return None
+        return None, sync_stats
     else:
         engagement_db_message = next_message_results[0]
+        sync_stats.add_event(CodaSyncEvents.READ_MESSAGE)
 
     log.info(f"Syncing message {engagement_db_message.message_id}...")
 
     # Ensure the message has a valid coda id. If it doesn't have one yet, write one back to the database.
     if engagement_db_message.coda_id is None:
         log.debug("Creating coda id")
+        sync_stats.add_event(CodaSyncEvents.SET_CODA_ID)
         engagement_db_message.coda_id = SHAUtils.sha_string(engagement_db_message.text)
         engagement_db.set_message(
             message=engagement_db_message,
@@ -82,14 +87,17 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
     # If the message exists in Coda, update the database message based on the labels assigned in Coda
     if coda_message is not None:
         log.debug("Message already exists in Coda")
-        _update_engagement_db_message_from_coda_message(engagement_db, engagement_db_message, coda_message, coda_config,
-                                                        transaction=transaction)
-        return engagement_db_message
+        update_sync_stats = _update_engagement_db_message_from_coda_message(
+            engagement_db, engagement_db_message, coda_message, coda_config, transaction=transaction
+        )
+        sync_stats.add_stats(update_sync_stats)
+        return engagement_db_message, sync_stats
 
     # The message isn't in Coda, so add it
+    sync_stats.add_event(CodaSyncEvents.ADD_TO_CODA)
     _add_message_to_coda(coda, dataset_config, coda_config.ws_correct_dataset_code_scheme, engagement_db_message)
 
-    return engagement_db_message
+    return engagement_db_message, sync_stats
 
 
 def _sync_engagement_db_dataset_to_coda(engagement_db, coda, coda_config, dataset_config, cache):
@@ -104,18 +112,23 @@ def _sync_engagement_db_dataset_to_coda(engagement_db, coda, coda_config, datase
     :type coda_config: src.engagement_db_coda_sync.configuration.CodaSyncConfiguration
     :param dataset_config: Configuration for the dataset to sync.
     :type dataset_config: src.engagement_db_coda_sync.configuration.CodaDatasetConfiguration
+    :return: Sync stats for the update.
+    :rtype: src.engagement_db_coda_sync.sync_stats.CodaSyncStats
     """
     last_seen_message = None if cache is None else cache.get_last_seen_message(dataset_config.engagement_db_dataset)
     synced_messages = 0
     synced_message_ids = set()
 
+    sync_stats = CodaSyncStats()
+
     first_run = True
     while first_run or last_seen_message is not None:
         first_run = False
 
-        last_seen_message = _sync_next_engagement_db_message_to_coda(
+        last_seen_message, message_sync_stats = _sync_next_engagement_db_message_to_coda(
             engagement_db.transaction(), engagement_db, coda, coda_config, dataset_config, last_seen_message
         )
+        sync_stats.add_stats(message_sync_stats)
 
         if last_seen_message is not None:
             synced_messages += 1
@@ -132,6 +145,8 @@ def _sync_engagement_db_dataset_to_coda(engagement_db, coda, coda_config, datase
         else:
             log.info(f"No more new messages in dataset {dataset_config.engagement_db_dataset}")
 
+    return sync_stats
+
 
 def sync_engagement_db_to_coda(engagement_db, coda, coda_config, cache_path=None):
     """
@@ -147,6 +162,7 @@ def sync_engagement_db_to_coda(engagement_db, coda, coda_config, cache_path=None
                        If None, runs in non-incremental mode.
     :type cache_path: str | None
     """
+    # Initialise the cache
     if cache_path is None:
         cache = None
         log.warning(f"No `cache_path` provided. This tool will process all relevant messages from all of time")
@@ -154,9 +170,20 @@ def sync_engagement_db_to_coda(engagement_db, coda, coda_config, cache_path=None
         log.info(f"Initialising Coda sync cache at '{cache_path}/engagement_db_to_coda'")
         cache = CodaSyncCache(f"{cache_path}/engagement_db_to_coda")
 
+    # Sync each dataset in turn to Coda
+    dataset_to_sync_stats = dict()  # of engagement db dataset -> CodaSyncStats
     for dataset_config in coda_config.dataset_configurations:
         log.info(f"Syncing engagement db dataset {dataset_config.engagement_db_dataset} to Coda dataset "
                  f"{dataset_config.coda_dataset_id}...")
-        _sync_engagement_db_dataset_to_coda(engagement_db, coda, coda_config, dataset_config, cache)
+        dataset_sync_stats = _sync_engagement_db_dataset_to_coda(engagement_db, coda, coda_config, dataset_config, cache)
+        dataset_to_sync_stats[dataset_config.engagement_db_dataset] = dataset_sync_stats
 
+    # Log the summaries of actions taken for each dataset then for all datasets combined.
+    all_sync_stats = CodaSyncStats()
+    for dataset_config in coda_config.dataset_configurations:
+        log.info(f"Summary of actions for engagement db dataset '{dataset_config.engagement_db_dataset}':")
+        dataset_to_sync_stats[dataset_config.engagement_db_dataset].print_summary()
+        all_sync_stats.add_stats(dataset_to_sync_stats[dataset_config.engagement_db_dataset])
 
+    log.info(f"Summary of actions for all datasets:")
+    all_sync_stats.print_summary()

--- a/src/engagement_db_coda_sync/engagement_db_to_coda.py
+++ b/src/engagement_db_coda_sync/engagement_db_to_coda.py
@@ -37,7 +37,7 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
     :type last_seen_message: engagement_database.data_models.Message | None
     :return: A tuple of:
              1. The engagement database message that was synced. If there was no new message to sync, returns None.
-             2. Sync stats for the next synced message.
+             2. Sync stats.
     :rtype: (engagement_database.data_models.Message | None, src.engagement_db_coda_sync.sync_stats.CodaSyncStats)
     """
     if last_seen_message is None:

--- a/src/engagement_db_coda_sync/engagement_db_to_coda.py
+++ b/src/engagement_db_coda_sync/engagement_db_to_coda.py
@@ -65,7 +65,7 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
         return None, sync_stats
     else:
         engagement_db_message = next_message_results[0]
-        sync_stats.add_event(CodaSyncEvents.READ_MESSAGE)
+        sync_stats.add_event(CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB)
 
     log.info(f"Syncing message {engagement_db_message.message_id}...")
 
@@ -94,7 +94,7 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
         return engagement_db_message, sync_stats
 
     # The message isn't in Coda, so add it
-    sync_stats.add_event(CodaSyncEvents.ADD_TO_CODA)
+    sync_stats.add_event(CodaSyncEvents.ADD_MESSAGE_TO_CODA)
     _add_message_to_coda(coda, dataset_config, coda_config.ws_correct_dataset_code_scheme, engagement_db_message)
 
     return engagement_db_message, sync_stats

--- a/src/engagement_db_coda_sync/sync_stats.py
+++ b/src/engagement_db_coda_sync/sync_stats.py
@@ -1,0 +1,41 @@
+from core_data_modules.logging import Logger
+
+log = Logger(__name__)
+
+
+class CodaSyncEvents:
+    READ_MESSAGE = "read_message"
+    SET_CODA_ID = "set_coda_id"
+    ADD_TO_CODA = "add_to_coda"
+    LABELS_MATCH = "labels_match"
+    UPDATE_ENGAGEMENT_DB_LABELS = "update_engagement_db_labels"
+    WS_CORRECTION = "ws_correction"
+
+
+class CodaSyncStats:
+    def __init__(self):
+        self.event_counts = {
+            CodaSyncEvents.READ_MESSAGE: 0,
+            CodaSyncEvents.SET_CODA_ID: 0,
+            CodaSyncEvents.ADD_TO_CODA: 0,
+            CodaSyncEvents.LABELS_MATCH: 0,
+            CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS: 0,
+            CodaSyncEvents.WS_CORRECTION: 0
+        }
+
+    def add_event(self, event):
+        if event not in self.event_counts:
+            self.event_counts[event] = 0
+        self.event_counts[event] += 1
+
+    def add_stats(self, stats):
+        for k, v in stats.event_counts.items():
+            self.event_counts[k] += v
+
+    def print_summary(self):
+        log.info(f"Messages read: {self.event_counts[CodaSyncEvents.READ_MESSAGE]}")
+        log.info(f"Coda ids set: {self.event_counts[CodaSyncEvents.SET_CODA_ID]}")
+        log.info(f"Messages added to Coda: {self.event_counts[CodaSyncEvents.ADD_TO_CODA]}")
+        log.info(f"Messages updated with labels from Coda: {self.event_counts[CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS]}")
+        log.info(f"Messages with labels already matching Coda: {self.event_counts[CodaSyncEvents.LABELS_MATCH]}")
+        log.info(f"Messages WS-corrected: {self.event_counts[CodaSyncEvents.WS_CORRECTION]}")

--- a/src/engagement_db_coda_sync/sync_stats.py
+++ b/src/engagement_db_coda_sync/sync_stats.py
@@ -4,9 +4,9 @@ log = Logger(__name__)
 
 
 class CodaSyncEvents:
-    READ_MESSAGE = "read_message"
+    READ_MESSAGE_FROM_ENGAGEMENT_DB = "read_message_from_engagement_db"
     SET_CODA_ID = "set_coda_id"
-    ADD_TO_CODA = "add_to_coda"
+    ADD_MESSAGE_TO_CODA = "add_message_to_coda"
     LABELS_MATCH = "labels_match"
     UPDATE_ENGAGEMENT_DB_LABELS = "update_engagement_db_labels"
     WS_CORRECTION = "ws_correction"
@@ -15,9 +15,9 @@ class CodaSyncEvents:
 class CodaSyncStats:
     def __init__(self):
         self.event_counts = {
-            CodaSyncEvents.READ_MESSAGE: 0,
+            CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB: 0,
             CodaSyncEvents.SET_CODA_ID: 0,
-            CodaSyncEvents.ADD_TO_CODA: 0,
+            CodaSyncEvents.ADD_MESSAGE_TO_CODA: 0,
             CodaSyncEvents.LABELS_MATCH: 0,
             CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS: 0,
             CodaSyncEvents.WS_CORRECTION: 0
@@ -33,9 +33,9 @@ class CodaSyncStats:
             self.event_counts[k] += v
 
     def print_summary(self):
-        log.info(f"Messages read: {self.event_counts[CodaSyncEvents.READ_MESSAGE]}")
+        log.info(f"Messages read from engagement db: {self.event_counts[CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB]}")
         log.info(f"Coda ids set: {self.event_counts[CodaSyncEvents.SET_CODA_ID]}")
-        log.info(f"Messages added to Coda: {self.event_counts[CodaSyncEvents.ADD_TO_CODA]}")
+        log.info(f"Messages added to Coda: {self.event_counts[CodaSyncEvents.ADD_MESSAGE_TO_CODA]}")
         log.info(f"Messages updated with labels from Coda: {self.event_counts[CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS]}")
         log.info(f"Messages with labels already matching Coda: {self.event_counts[CodaSyncEvents.LABELS_MATCH]}")
         log.info(f"Messages WS-corrected: {self.event_counts[CodaSyncEvents.WS_CORRECTION]}")


### PR DESCRIPTION
This lets us see totals at the end of the script, which makes monitoring much easier, and will also make --dry-run outputs easier to interpret once we've added that flag. It could also be used to improve the level of detail on the monitoring dashboard by simply uploading the final stats of each run to the dashboards in future.

If you have suggestions for a better way of doing this then I'm very happy to re-work what's here, otherwise this should form the basis for similar monitoring improvements to the other stages.

Sample outputs:
```
2021-07-26T14:47:15.664765+00:00 INFO src.engagement_db_coda_sync.engagement_db_to_coda: Summary of actions for all datasets:
2021-07-26T14:47:15.664812+00:00 INFO src.engagement_db_coda_sync.sync_stats: Messages read: 16
2021-07-26T14:47:15.664856+00:00 INFO src.engagement_db_coda_sync.sync_stats: Coda ids set: 8
2021-07-26T14:47:15.664900+00:00 INFO src.engagement_db_coda_sync.sync_stats: Messages added to Coda: 0
2021-07-26T14:47:15.664945+00:00 INFO src.engagement_db_coda_sync.sync_stats: Messages updated with labels from Coda: 4
2021-07-26T14:47:15.664990+00:00 INFO src.engagement_db_coda_sync.sync_stats: Messages with labels already matching Coda: 12
2021-07-26T14:47:15.665034+00:00 INFO src.engagement_db_coda_sync.sync_stats: Messages WS-corrected: 0
```