### PR TITLE
Convert analysis to column-view format

### DIFF
--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -8,11 +8,11 @@ from src.pipeline_configuration_spec import *
 PIPELINE_CONFIGURATION = PipelineConfiguration(
     pipeline_name="engagement-db-test",
     # TODO: store in messages and individuals_filter list of functions.
-    project_start_date=isoparse("2021-03-01T10:30:00+03:00"),
-    project_end_date=isoparse("2100-01-01T00:00:00+03:00"),
-    test_participant_uuids=[
-        "avf-participant-uuid-51c15546-58a0-4ab1-b465-e65b71462a8f"
-    ],
+    # project_start_date=isoparse("2021-03-01T10:30:00+03:00"),
+    # project_end_date=isoparse("2100-01-01T00:00:00+03:00"),
+    # test_participant_uuids=[
+    #     "avf-participant-uuid-51c15546-58a0-4ab1-b465-e65b71462a8f"
+    # ],
     engagement_database=EngagementDatabaseClientConfiguration(
         credentials_file_url="gs://avf-credentials/firebase-test.json",
         database_path="engagement_db_experiments/experimental_test"

--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -8,11 +8,11 @@ from src.pipeline_configuration_spec import *
 PIPELINE_CONFIGURATION = PipelineConfiguration(
     pipeline_name="engagement-db-test",
     # TODO: store in messages and individuals_filter list of functions.
-    # project_start_date=isoparse("2021-03-01T10:30:00+03:00"),
-    # project_end_date=isoparse("2100-01-01T00:00:00+03:00"),
-    # test_participant_uuids=[
-    #     "avf-participant-uuid-51c15546-58a0-4ab1-b465-e65b71462a8f"
-    # ],
+    project_start_date=isoparse("2021-03-01T10:30:00+03:00"),
+    project_end_date=isoparse("2100-01-01T00:00:00+03:00"),
+    test_participant_uuids=[
+        "avf-participant-uuid-51c15546-58a0-4ab1-b465-e65b71462a8f"
+    ],
     engagement_database=EngagementDatabaseClientConfiguration(
         credentials_file_url="gs://avf-credentials/firebase-test.json",
         database_path="engagement_db_experiments/experimental_test"

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -160,7 +160,7 @@ def _fold_messages_by_uid(user, messages_traced_data):
     return participants_traced_data_map
 
 
-def _analysis_dataset_config_to_column_config(analysis_dataset_config):
+def _analysis_dataset_config_to_column_configs(analysis_dataset_config):
     """
     Converts an analysis dataset configuration to the relevant "column-view" configurations.
 
@@ -253,7 +253,7 @@ def _add_message_to_column_td(user, message_td, column_td, analysis_config):
     analysis_dataset_config = _analysis_dataset_config_for_message(analysis_config.dataset_configurations, message)
 
     # Convert the analysis dataset config to its "column-view" configurations
-    column_configs = _analysis_dataset_config_to_column_config(analysis_dataset_config)
+    column_configs = _analysis_dataset_config_to_column_configs(analysis_dataset_config)
 
     new_data = dict()
 
@@ -404,6 +404,11 @@ def export_production_file(traced_data_iterable, analysis_config, export_path):
     with open(export_path, "w") as f:
         headers = ["participant_uuid"] + [c.raw_dataset for c in analysis_config.dataset_configurations]
         TracedDataCSVIO.export_traced_data_iterable_to_csv(traced_data_iterable, f, headers)
+
+
+def export_analysis_file(traced_data_iterable, analysis_config, export_path):
+    headers = ["participant_uuid"]
+    column_configs = analysis_config.dataset_configurations
 
 
 def export_traced_data(traced_data, export_path):

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -213,16 +213,16 @@ def _add_message_to_column_td(user, message_td, column_td, analysis_config):
     # Convert the analysis dataset config to its "column-view" configurations
     column_configs = _analysis_dataset_config_to_column_configs(analysis_dataset_config)
 
-    new_data = dict()
+    updated_column_data = dict()
 
     # Add this message's raw text to the the raw_dataset column in the column-view TracedData.
     # If the TracedData already contains data here, append this text to the existing, previously added texts by
     # concatenating.
     existing_text = column_td.get(analysis_dataset_config.raw_dataset)
     if existing_text is None:
-        new_data[analysis_dataset_config.raw_dataset] = message.text
+        updated_column_data[analysis_dataset_config.raw_dataset] = message.text
     else:
-        new_data[analysis_dataset_config.raw_dataset] = FoldStrategies.concatenate(existing_text, message.text)
+        updated_column_data[analysis_dataset_config.raw_dataset] = FoldStrategies.concatenate(existing_text, message.text)
 
     # For each column config, get the latest, normalised labels under that column config's code scheme, and them
     # to the column-view TracedData.
@@ -237,9 +237,9 @@ def _add_message_to_column_td(user, message_td, column_td, analysis_config):
         latest_labels_with_code_scheme = [label.to_dict() for label in latest_labels_with_code_scheme]
         existing_labels = column_td.get(column_config.coded_field)
         if existing_labels is None:
-            new_data[column_config.coded_field] = latest_labels_with_code_scheme
+            updated_column_data[column_config.coded_field] = latest_labels_with_code_scheme
         else:
-            new_data[column_config.coded_field] = FoldStrategies.list_of_labels(
+            updated_column_data[column_config.coded_field] = FoldStrategies.list_of_labels(
                 column_config.code_scheme, existing_labels, latest_labels_with_code_scheme
             )
 
@@ -250,7 +250,7 @@ def _add_message_to_column_td(user, message_td, column_td, analysis_config):
 
     # Write the new data to the column-view TracedData
     # (we do this after appending the message_td so the TracedData is slightly easier to read)
-    column_td.append_data(new_data, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+    column_td.append_data(updated_column_data, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
 
 def _convert_to_messages_column_format(user, messages_traced_data, analysis_config):

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -208,21 +208,21 @@ def _add_message_to_column_td(user, message_td, column_td, analysis_config):
     message = Message.from_dict(dict(message_td))
 
     # Get the analysis dataset configuration for this message
-    analysis_dataset_config = _analysis_dataset_config_for_message(analysis_config.dataset_configurations, message)
+    message_analysis_dataset_config = _analysis_dataset_config_for_message(analysis_config.dataset_configurations, message)
 
     # Convert the analysis dataset config to its "column-view" configurations
-    column_configs = _analysis_dataset_config_to_column_configs(analysis_dataset_config)
+    column_configs = _analysis_dataset_config_to_column_configs(message_analysis_dataset_config)
 
     updated_column_data = dict()
 
     # Add this message's raw text to the the raw_dataset column in the column-view TracedData.
     # If the TracedData already contains data here, append this text to the existing, previously added texts by
     # concatenating.
-    existing_text = column_td.get(analysis_dataset_config.raw_dataset)
+    existing_text = column_td.get(message_analysis_dataset_config.raw_dataset)
     if existing_text is None:
-        updated_column_data[analysis_dataset_config.raw_dataset] = message.text
+        updated_column_data[message_analysis_dataset_config.raw_dataset] = message.text
     else:
-        updated_column_data[analysis_dataset_config.raw_dataset] = FoldStrategies.concatenate(existing_text, message.text)
+        updated_column_data[message_analysis_dataset_config.raw_dataset] = FoldStrategies.concatenate(existing_text, message.text)
 
     # For each column config, get the latest, normalised labels under that column config's code scheme, and them
     # to the column-view TracedData.

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -384,7 +384,7 @@ def _convert_to_participants_column_format(user, messages_traced_data, analysis_
         participant = participants_by_column[message.participant_uuid]
         _add_message_to_column_td(user, msg_td, participant, analysis_config)
 
-    return participants_by_column.values()
+    return list(participants_by_column.values())
 
 
 def export_production_file(traced_data_iterable, analysis_config, export_path):

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -1,4 +1,4 @@
-from core_data_modules.analysis import AnalysisConfiguration, engagement_counts
+from core_data_modules.analysis import AnalysisConfiguration
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data import TracedData, Metadata
 from core_data_modules.traced_data.io import TracedDataJsonIO, TracedDataCSVIO

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -1,4 +1,4 @@
-from core_data_modules.analysis import AnalysisConfiguration
+from core_data_modules.analysis import AnalysisConfiguration, engagement_counts
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data import TracedData, Metadata
 from core_data_modules.traced_data.io import TracedDataJsonIO, TracedDataCSVIO
@@ -200,11 +200,15 @@ def _add_message_to_column_td(user, message, column_td, analysis_config):
     # Get the latest labels under the code scheme for each column config, and append them to the labels for that
     # participant
     for column_config in column_configs:
-        latest_labels = message.get_latest_labels()
-        if len(latest_labels) == 0:
+        relevant_labels = []
+        for label in message.get_latest_labels():
+            if label.scheme_id.startswith(column_config.code_scheme.scheme_id):
+                # Normalise scheme id
+                label.scheme_id = column_config.code_scheme.scheme_id
+                relevant_labels.append(label.to_dict())
+
+        if len(relevant_labels) == 0:
             continue
-        relevant_labels = [label.to_dict() for label in latest_labels
-                           if label.scheme_id.startswith(column_config.code_scheme.scheme_id)]
 
         if column_config.coded_field in column_td:
             existing_participant_labels = column_td[column_config.coded_field]

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -178,13 +178,13 @@ def _analysis_dataset_config_to_column_configs(analysis_dataset_config):
     """
     column_configs = []
     for coding_config in analysis_dataset_config.coding_configs:
-        config = AnalysisConfiguration(
+        column_config = AnalysisConfiguration(
             dataset_name=coding_config.analysis_dataset,
             raw_field=analysis_dataset_config.raw_dataset,
             coded_field=f"{coding_config.analysis_dataset}_labels",
             code_scheme=coding_config.code_scheme
         )
-        column_configs.append(config)
+        column_configs.append(column_config)
     return column_configs
 
 


### PR DESCRIPTION
As discussed offline, analysis needs to be (roughly) 3 phase:
1. Process message-by-message (incrementally get messages, filter irrelevant messages, impute codes etc.)
2. Convert the data format from a list of messages to two aggregated lists, one grouped by participant and the other grouped by rqa message.
3. Process the new formats (further impute codes, export analysis files, run automated analysis etc.)

This PR does the conversion (step 2). It also exports production files (sorry @DanielMwendwa for reimplementing this, but they trivially dropped out of the new format in 3 loc and were super useful here as a debug tool).

I think the format is right and will be easy to use with the existing automated analysis modules we have. It even uses the existing AnalysisConfiguration from core. My biggest issue here has been the terminology, for example we need to distinguish a message, message traced data, list of message traced data, and aggregated column-view rqa message traced data :/ If there's anything that's still confusing here we can think more about how to tighten this up.

