### PR TITLE
Add Drive upload

### DIFF
--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -1,7 +1,5 @@
 from core_data_modules.cleaners import swahili
-
 from dateutil.parser import isoparse
-
 
 from src.pipeline_configuration_spec import *
 
@@ -93,6 +91,10 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
         )
     ),
     analysis=AnalysisConfiguration(
+        google_drive_upload=GoogleDriveUploadConfiguration(
+            credentials_file_url="gs://avf-credentials/pipeline-runner-service-acct-avf-data-core-64cc71459fe7.json",
+            drive_dir="pipeline_upload_test"
+        ),
         dataset_configurations=[
             AnalysisDatasetConfiguration(
                 engagement_db_datasets=["s01e01"],

--- a/engagement_db_to_analysis.py
+++ b/engagement_db_to_analysis.py
@@ -36,4 +36,6 @@ if __name__ == "__main__":
     uuid_table = pipeline_config.uuid_table.init_uuid_table_client(google_cloud_credentials_file_path)
     engagement_db = pipeline_config.engagement_database.init_engagement_db_client(google_cloud_credentials_file_path)
 
-    generate_analysis_files(user, pipeline_config, engagement_db, output_dir, incremental_cache_path)
+    generate_analysis_files(
+        user, google_cloud_credentials_file_path, pipeline_config, engagement_db, output_dir, incremental_cache_path
+    )

--- a/src/engagement_db_to_analysis/configuration.py
+++ b/src/engagement_db_to_analysis/configuration.py
@@ -39,5 +39,12 @@ class AnalysisDatasetConfiguration:
 
 
 @dataclass
+class GoogleDriveUploadConfiguration:
+    credentials_file_url: str
+    drive_dir: str
+
+
+@dataclass
 class AnalysisConfiguration:
     dataset_configurations: [AnalysisDatasetConfiguration]
+    google_drive_upload: Optional[GoogleDriveUploadConfiguration] = None

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -183,6 +183,7 @@ def generate_analysis_files(user, google_cloud_credentials_file_path, pipeline_c
     if pipeline_config.analysis_configs.google_drive_upload is None:
         log.debug("Not uploading to Google Drive, because the 'google_drive_upload' configuration was None")
     else:
+        log.info("Uploading outputs to Google Drive...")
         google_drive_upload.init_client(
             google_cloud_credentials_file_path,
             pipeline_config.analysis_configs.google_drive_upload.credentials_file_url
@@ -192,4 +193,6 @@ def generate_analysis_files(user, google_cloud_credentials_file_path, pipeline_c
         google_drive_upload.upload_file(f"{output_dir}/production.csv", drive_dir)
         google_drive_upload.upload_file(f"{output_dir}/messages.csv", drive_dir)
         google_drive_upload.upload_file(f"{output_dir}/participants.csv", drive_dir)
-        google_drive_upload.upload_all_files_in_dir(f"{output_dir}/automated-analysis", drive_dir, recursive=True)
+        google_drive_upload.upload_all_files_in_dir(
+            f"{output_dir}/automated-analysis", f"{drive_dir}/automated-analysis", recursive=True
+        )

--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -180,16 +180,16 @@ def generate_analysis_files(user, google_cloud_credentials_file_path, pipeline_c
 
     run_automated_analysis(messages_by_column, participants_by_column, pipeline_config.analysis, f"{output_dir}/automated-analysis")
 
-    if pipeline_config.analysis_configs.google_drive_upload is None:
+    if pipeline_config.analysis.google_drive_upload is None:
         log.debug("Not uploading to Google Drive, because the 'google_drive_upload' configuration was None")
     else:
         log.info("Uploading outputs to Google Drive...")
         google_drive_upload.init_client(
             google_cloud_credentials_file_path,
-            pipeline_config.analysis_configs.google_drive_upload.credentials_file_url
+            pipeline_config.analysis.google_drive_upload.credentials_file_url
         )
 
-        drive_dir = pipeline_config.analysis_configs.google_drive_upload.drive_dir
+        drive_dir = pipeline_config.analysis.google_drive_upload.drive_dir
         google_drive_upload.upload_file(f"{output_dir}/production.csv", drive_dir)
         google_drive_upload.upload_file(f"{output_dir}/messages.csv", drive_dir)
         google_drive_upload.upload_file(f"{output_dir}/participants.csv", drive_dir)

--- a/src/engagement_db_to_analysis/google_drive_upload.py
+++ b/src/engagement_db_to_analysis/google_drive_upload.py
@@ -1,0 +1,69 @@
+import json
+import os
+
+from core_data_modules.logging import Logger
+from storage.google_cloud import google_cloud_utils
+from storage.google_drive import drive_client_wrapper
+
+log = Logger(__name__)
+
+
+def init_client(google_cloud_credentials_file_path, drive_credentials_file_url):
+    """
+    Initialises the `drive_client_wrapper`.
+
+    :param google_cloud_credentials_file_path: Path to the Google Cloud service account credentials file to use to
+                                               access the credentials bucket.
+    :type google_cloud_credentials_file_path: str
+    :param drive_credentials_file_url: GS URL to the Google Drive service account credentials file in the credentials
+                                       bucket.
+    :type drive_credentials_file_url: str
+    """
+    log.info(f"Downloading Google Drive service account credentials...")
+    credentials_info = json.loads(google_cloud_utils.download_blob_to_string(
+        google_cloud_credentials_file_path,
+        drive_credentials_file_url
+    ))
+    drive_client_wrapper.init_client_from_info(credentials_info)
+
+
+def upload_file(source_file_path, target_dir):
+    """
+    Uploads a file from local disk to Google Drive.
+
+    :param source_file_path: Path to a local file on disk to upload.
+    :type source_file_path: str
+    :param target_dir: Path to target directory on Google Drive.
+    :type target_dir: str
+    """
+    log.info(f"Uploading '{source_file_path}' to Google Drive path '{target_dir}'...")
+    drive_client_wrapper.update_or_create(
+        source_file_path=source_file_path,
+        target_folder_path=target_dir,
+        target_file_name=os.path.basename(source_file_path),
+        target_folder_is_shared_with_me=True,
+        recursive=True,
+        fix_duplicates=True
+    )
+
+
+def upload_all_files_in_dir(source_dir_path, target_dir, recursive=False):
+    """
+    Uploads all files in a directory to Google Drive.
+
+    Note this is non-recursive i.e. files in subdirectories will not be uploaded.
+
+    :param source_dir_path: Path to a local directory on disk to upload files from.
+    :type source_dir_path: str
+    :param target_dir: Path to target directory on Google Drive.
+    :type target_dir: str
+    """
+    source_dir_contents = [os.path.join(source_dir_path, f) for f in os.listdir(source_dir_path)]
+    for path in source_dir_contents:
+        if os.path.isfile(path):
+            upload_file(path, target_dir)
+
+    if recursive:
+        for path in source_dir_contents:
+            if not os.path.isfile(path):
+                upload_all_files_in_dir(path, f"{target_dir}/{os.path.basename(path)}", recursive=True)

--- a/src/engagement_db_to_analysis/google_drive_upload.py
+++ b/src/engagement_db_to_analysis/google_drive_upload.py
@@ -57,11 +57,23 @@ def upload_all_files_in_dir(source_dir_path, target_dir, recursive=False):
     :type source_dir_path: str
     :param target_dir: Path to target directory on Google Drive.
     :type target_dir: str
+    :param recursive: Whether to recursively upload any sub-directories in this directory too.
+    :type recursive: bool
     """
     source_dir_contents = [os.path.join(source_dir_path, f) for f in os.listdir(source_dir_path)]
+
+    # Batch upload all the files in this directory
+    file_paths = []
     for path in source_dir_contents:
         if os.path.isfile(path):
-            upload_file(path, target_dir)
+            file_paths.append(path)
+    drive_client_wrapper.update_or_create_batch(
+        source_file_paths=file_paths,
+        target_folder_path=target_dir,
+        target_folder_is_shared_with_me=True,
+        recursive=True,
+        fix_duplicates=True
+    )
 
     if recursive:
         for path in source_dir_contents:

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -12,8 +12,10 @@ from src.engagement_db_to_rapid_pro.configuration import (EngagementDBToRapidPro
                                                           WriteModes, ContactField)
 from src.rapid_pro_to_engagement_db.configuration import (FlowResultConfiguration, UuidFilter,
                                                           RapidProToEngagementDBConfiguration)
-from src.engagement_db_to_analysis.configuration import (AnalysisDatasetConfiguration, DatasetTypes,
-    AgeCategoryConfiguration, KenyaAnalysisLocations, CodingConfiguration, AnalysisConfiguration)
+from src.engagement_db_to_analysis.configuration import (
+    AnalysisDatasetConfiguration, DatasetTypes, AgeCategoryConfiguration, KenyaAnalysisLocations, CodingConfiguration,
+    GoogleDriveUploadConfiguration, AnalysisConfiguration
+)
 
 
 def load_code_scheme(fname):


### PR DESCRIPTION
Test uploading to here https://drive.google.com/drive/folders/1svzLQuAbiwVWBlB_22nOemXp3yepdp9x?usp=sharing

Rather than uploading in a new stage this uploads directly at the end of the analysis stage. This makes analysis easier to run and maintain, because we only need to think about 1 script, not 2, and this is more easily possible now thanks to the work we did last year improving the reliability of uploads.