### PR TITLE
Print summary of sync events at end of coda -> engagement db sync

### DIFF
--- a/src/common/sync_stats.py
+++ b/src/common/sync_stats.py
@@ -11,6 +11,10 @@ class SyncStats(ABC):
             self.event_counts[event] = 0
         self.event_counts[event] += 1
 
+    def add_events(self, events):
+        for event in events:
+            self.add_event(event)
+
     def add_stats(self, stats):
         for k, v in stats.event_counts.items():
             self.event_counts[k] += v

--- a/src/engagement_db_coda_sync/coda_to_engagement_db.py
+++ b/src/engagement_db_coda_sync/coda_to_engagement_db.py
@@ -4,6 +4,7 @@ from google.cloud import firestore
 
 from src.engagement_db_coda_sync.cache import CodaSyncCache
 from src.engagement_db_coda_sync.lib import _update_engagement_db_message_from_coda_message
+from src.engagement_db_coda_sync.sync_stats import CodaToEngagementDBSyncStats, CodaSyncEvents
 
 log = Logger(__name__)
 
@@ -24,7 +25,11 @@ def _sync_coda_message_to_engagement_db(transaction, coda_message, engagement_db
     :type engagement_db_dataset: str
     :param coda_config: Configuration for the update.
     :type coda_config: src.engagement_db_coda_sync.configuration.CodaSyncConfiguration
+    :return Sync stats.
+    :rtype src.engagement_db_coda_sync.sync_stats.CodaToEngagementDBSyncStats
     """
+    sync_stats = CodaToEngagementDBSyncStats()
+
     # Get the messages in the engagement database that match this dataset and coda message id
     engagement_db_messages = engagement_db.get_messages(
         firestore_query_filter=lambda q: q
@@ -35,12 +40,18 @@ def _sync_coda_message_to_engagement_db(transaction, coda_message, engagement_db
     )
     log.info(f"{len(engagement_db_messages)} engagement db message(s) match Coda message {coda_message.message_id}")
 
+    for _ in engagement_db_messages:
+        sync_stats.add_event(CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB)
+
     # Update each of the matching messages with the labels currently in Coda.
     for i, engagement_db_message in enumerate(engagement_db_messages):
         log.info(f"Processing matching engagement message {i + 1}/{len(engagement_db_messages)}: "
                  f"{engagement_db_message.message_id}...")
-        _update_engagement_db_message_from_coda_message(
+        message_sync_events = _update_engagement_db_message_from_coda_message(
             engagement_db, engagement_db_message, coda_message, coda_config, transaction=transaction)
+        sync_stats.add_events(message_sync_events)
+
+    return sync_stats
 
 
 def _sync_coda_dataset_to_engagement_db(coda, engagement_db, coda_config, dataset_config, cache=None):
@@ -55,24 +66,34 @@ def _sync_coda_dataset_to_engagement_db(coda, engagement_db, coda_config, datase
     :type coda_config: src.engagement_db_coda_sync.configuration.CodaSyncConfiguration
     :param cache: Coda sync cache.
     :type cache: src.engagement_db_coda_sync.cache.CodaSyncCache | None
+    :return Sync stats for the update.
+    :rtype: src.engagement_db_coda_sync.sync_stats.CodaToEngagementDBSyncStats
     """
     log.info(f"Getting messages from Coda dataset {dataset_config.coda_dataset_id}...")
+
+    sync_stats = CodaToEngagementDBSyncStats()
+
     coda_messages = coda.get_dataset_messages(
         dataset_config.coda_dataset_id,
         last_updated_after=None if cache is None else cache.get_last_updated_timestamp(dataset_config.coda_dataset_id)
     )
+    for _ in coda_messages:
+        sync_stats.add_event(CodaSyncEvents.READ_MESSAGE_FROM_CODA)
 
     for i, coda_message in enumerate(coda_messages):
         log.info(f"Processing Coda message {i + 1}/{len(coda_messages)}: {coda_message.message_id}...")
-        _sync_coda_message_to_engagement_db(
+        message_sync_stats = _sync_coda_message_to_engagement_db(
             engagement_db.transaction(), coda_message, engagement_db, dataset_config.engagement_db_dataset,
             coda_config
         )
+        sync_stats.add_stats(message_sync_stats)
 
     seen_timestamps = [msg.last_updated for msg in coda_messages if msg.last_updated is not None]
     if cache is not None and len(seen_timestamps) > 0:
         most_recently_updated_timestamp = sorted(seen_timestamps)[-1]
         cache.set_last_updated_timestamp(dataset_config.coda_dataset_id, most_recently_updated_timestamp)
+
+    return sync_stats
 
 
 def sync_coda_to_engagement_db(coda, engagement_db, coda_config, cache_path=None):
@@ -98,7 +119,19 @@ def sync_coda_to_engagement_db(coda, engagement_db, coda_config, cache_path=None
         cache = CodaSyncCache(f"{cache_path}/coda_to_engagement_db")
 
     # Sync each Coda dataset to the engagement db in turn
+    dataset_to_sync_stats = dict()  # of coda dataset id -> CodaToEngagementDBSyncStats
     for dataset_config in coda_config.dataset_configurations:
         log.info(f"Syncing Coda dataset {dataset_config.coda_dataset_id} to engagement db dataset "
                  f"{dataset_config.coda_dataset_id}")
-        _sync_coda_dataset_to_engagement_db(coda, engagement_db, coda_config, dataset_config, cache)
+        dataset_sync_stats = _sync_coda_dataset_to_engagement_db(coda, engagement_db, coda_config, dataset_config, cache)
+        dataset_to_sync_stats[dataset_config.coda_dataset_id] = dataset_sync_stats
+
+    # Log the summaries of actions taken for each dataset then for all datasets combined.
+    all_sync_stats = CodaToEngagementDBSyncStats()
+    for dataset_config in coda_config.dataset_configurations:
+        log.info(f"Summary of actions for Coda dataset '{dataset_config.coda_dataset_id}':")
+        dataset_to_sync_stats[dataset_config.coda_dataset_id].print_summary()
+        all_sync_stats.add_stats(dataset_to_sync_stats[dataset_config.coda_dataset_id])
+
+    log.info(f"Summary of actions for all datasets:")
+    all_sync_stats.print_summary()

--- a/src/engagement_db_coda_sync/engagement_db_to_coda.py
+++ b/src/engagement_db_coda_sync/engagement_db_to_coda.py
@@ -87,10 +87,10 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
     # If the message exists in Coda, update the database message based on the labels assigned in Coda
     if coda_message is not None:
         log.debug("Message already exists in Coda")
-        update_sync_stats = _update_engagement_db_message_from_coda_message(
+        update_sync_events = _update_engagement_db_message_from_coda_message(
             engagement_db, engagement_db_message, coda_message, coda_config, transaction=transaction
         )
-        sync_stats.add_stats(update_sync_stats)
+        sync_stats.add_events(update_sync_events)
         return engagement_db_message, sync_stats
 
     # The message isn't in Coda, so add it
@@ -173,7 +173,7 @@ def sync_engagement_db_to_coda(engagement_db, coda, coda_config, cache_path=None
         cache = CodaSyncCache(f"{cache_path}/engagement_db_to_coda")
 
     # Sync each dataset in turn to Coda
-    dataset_to_sync_stats = dict()  # of engagement db dataset -> CodaSyncStats
+    dataset_to_sync_stats = dict()  # of engagement db dataset -> EngagementDBToCodaSyncStats
     for dataset_config in coda_config.dataset_configurations:
         log.info(f"Syncing engagement db dataset {dataset_config.engagement_db_dataset} to Coda dataset "
                  f"{dataset_config.coda_dataset_id}...")

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -166,11 +166,11 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
     :type coda_config:  src.engagement_db_coda_sync.configuration.CodaSyncConfiguration
     :param transaction: Transaction in the engagement database to perform the update in.
     :type transaction: google.cloud.firestore.Transaction | None
-    :return: Sync stats for the update.
-    :rtype: src.engagement_db_coda_sync.sync_stats.EngagementDBToCodaSyncStats
+    :return: Sync events for the update.
+    :rtype: list of str
     """
     coda_dataset_config = coda_config.get_dataset_config_by_engagement_db_dataset(engagement_db_message.dataset)
-    sync_stats = EngagementDBToCodaSyncStats()
+    sync_events = []
 
     # Check if the labels in the engagement database message already match those from the coda message, and that
     # we don't need to WS-correct (in other words, that the dataset is correct).
@@ -178,8 +178,8 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
     ws_code = _get_ws_code(coda_message, coda_dataset_config, coda_config.ws_correct_dataset_code_scheme)
     if engagement_db_message.labels == coda_message.labels and ws_code is None:
         log.debug("Labels match")
-        sync_stats.add_event(CodaSyncEvents.LABELS_MATCH)
-        return sync_stats
+        sync_events.append(CodaSyncEvents.LABELS_MATCH)
+        return sync_events
 
     log.debug("Updating database message labels to match those in Coda")
 
@@ -223,8 +223,8 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
             transaction=transaction
         )
 
-        sync_stats.add_event(CodaSyncEvents.WS_CORRECTION)
-        return sync_stats
+        sync_events.append(CodaSyncEvents.WS_CORRECTION)
+        return sync_events
 
     # We didn't find a WS label, so simply update the engagement database message to have the same labels as the
     # message in Coda.
@@ -237,5 +237,5 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
         transaction=transaction
     )
 
-    sync_stats.add_event(CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS)
-    return sync_stats
+    sync_events.append(CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS)
+    return sync_events

--- a/src/engagement_db_coda_sync/sync_stats.py
+++ b/src/engagement_db_coda_sync/sync_stats.py
@@ -33,3 +33,21 @@ class EngagementDBToCodaSyncStats(SyncStats):
         log.info(f"Messages updated with labels from Coda: {self.event_counts[CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS]}")
         log.info(f"Messages with labels already matching Coda: {self.event_counts[CodaSyncEvents.LABELS_MATCH]}")
         log.info(f"Messages WS-corrected: {self.event_counts[CodaSyncEvents.WS_CORRECTION]}")
+
+
+class CodaToEngagementDBSyncStats(SyncStats):
+    def __init__(self):
+        super().__init__({
+            CodaSyncEvents.READ_MESSAGE_FROM_CODA: 0,
+            CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB: 0,
+            CodaSyncEvents.LABELS_MATCH: 0,
+            CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS: 0,
+            CodaSyncEvents.WS_CORRECTION: 0
+        })
+
+    def print_summary(self):
+        log.info(f"Messages read from Coda: {self.event_counts[CodaSyncEvents.READ_MESSAGE_FROM_CODA]}")
+        log.info(f"Messages read from engagement db: {self.event_counts[CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB]}")
+        log.info(f"Messages updated with labels from Coda: {self.event_counts[CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS]}")
+        log.info(f"Messages with labels already matching Coda: {self.event_counts[CodaSyncEvents.LABELS_MATCH]}")
+        log.info(f"Messages WS-corrected: {self.event_counts[CodaSyncEvents.WS_CORRECTION]}")


### PR DESCRIPTION
Follows the same pattern as the engagement db -> coda sync. Adapts the common code to return lists of sync events instead of EngagementDBToCodaSyncStats 