### PR TITLE
Generalise impute_location_codes

### DIFF
--- a/src/engagement_db_to_analysis/code_imputation_functions.py
+++ b/src/engagement_db_to_analysis/code_imputation_functions.py
@@ -306,6 +306,138 @@ def _make_location_code(scheme, clean_value):
         return scheme.get_code_with_match_value(clean_value)
 
 
+def _impute_location_codes(user, messages_traced_data, location_engagement_db_datasets, coding_config_cleaner_tuples):
+    """
+    Imputes location labels for location dataset messages.
+
+    :param user: Identifier of user running the pipeline.
+    :type user: str
+    :param messages_traced_data: Messages TracedData objects to impute age_category.
+    :type messages_traced_data: list of TracedData
+    :param location_engagement_db_datasets: Engagement db datasets to impute location for. Messages whose dataset is
+                                            in this list will have their locations imputed.
+    :type location_engagement_db_datasets: list of str
+    :param coding_config_cleaner_tuples: List of tuples of:
+                                          (i)  The coding configuration for a location variable
+                                          (ii) A function which, given a location code, returns the location code for
+                                               this location variable.
+                                         For example: (
+                                            <coding configuration for Kenyan county>,
+                                            <function that takes Kenyan county/constituency codes and returns the
+                                             appropriate county code>
+                                        )
+    :type coding_config_cleaner_tuples: list of (
+            src.engagement_db_to_analysis.configuration.CodingConfiguration, func of str -> str)
+    """
+    imputed_normal_labels = 0
+    imputed_meta_labels = 0
+    imputed_control_labels = 0
+    detected_coding_errors = 0
+
+    for message_traced_data in messages_traced_data:
+        message = Message.from_dict(dict(message_traced_data))
+        if message.dataset not in location_engagement_db_datasets:
+            continue
+
+        # Up to 1 location code should have been assigned in Coda. Search for that code, ensuring that only 1 has been
+        # assigned or, if multiple have been assigned, that they are non-conflicting control codes.
+        # Multiple normal codes will be converted to Coding Error, even if they were compatible (e.g. langata + nairobi)
+        location_code = None
+        for coding_config, _ in coding_config_cleaner_tuples:
+            latest_coding_config_labels = get_latest_labels_with_code_scheme(message, coding_config.code_scheme)
+
+            if len(latest_coding_config_labels) > 0:
+                latest_coding_config_label = latest_coding_config_labels[0]
+
+                coda_code = coding_config.code_scheme.get_code_with_code_id(latest_coding_config_label.code_id)
+                if location_code is not None:
+                    if location_code.code_id != coda_code.code_id:
+                        location_code = coding_config.code_scheme.get_code_with_control_code(
+                            Codes.CODING_ERROR
+                        )
+                        detected_coding_errors += 1
+                else:
+                    location_code = coda_code
+
+        # If a control or meta code was found, set all other location keys to that control/meta code,
+        # otherwise convert the provided location to the other locations in the hierarchy.
+        if location_code.code_type == CodeTypes.CONTROL:
+            for coding_config, _ in coding_config_cleaner_tuples:
+                control_code_label = CleaningUtils.make_label_from_cleaner_code(
+                    coding_config.code_scheme,
+                    coding_config.code_scheme.get_code_with_control_code(location_code.control_code),
+                    Metadata.get_call_location())
+
+                _insert_label_to_message_td(user, message_traced_data, control_code_label)
+                imputed_control_labels += 1
+        elif location_code.code_type == CodeTypes.META:
+            for coding_config, _ in coding_config_cleaner_tuples:
+                meta_code_label = CleaningUtils.make_label_from_cleaner_code(
+                    coding_config.code_scheme,
+                    coding_config.code_scheme.get_code_with_meta_code(location_code.meta_code),
+                    Metadata.get_call_location())
+
+                _insert_label_to_message_td(user, message_traced_data, meta_code_label)
+                imputed_meta_labels += 1
+        else:
+            location = location_code.match_values[0]
+            for coding_config, cleaner in coding_config_cleaner_tuples:
+                label = CleaningUtils.make_label_from_cleaner_code(
+                    coding_config.code_scheme,
+                    _make_location_code(coding_config.code_scheme, cleaner(location)),
+                    Metadata.get_call_location()
+                )
+                _insert_label_to_message_td(user, message_traced_data, label)
+            imputed_normal_labels += 1
+
+    log.info(f"Detected {detected_coding_errors} coding errors, and imputed {imputed_normal_labels} normal, "
+             f"{imputed_meta_labels} meta, and {imputed_control_labels} control location labels.")
+
+
+def _impute_kenya_location_codes_2(user, messages_traced_data, analysis_dataset_configs):
+    """
+    Imputes Kenya location labels for location dataset messages.
+
+    :param user: Identifier of user running the pipeline.
+    :type user: str
+    :param messages_traced_data: Messages TracedData objects to impute age_category.
+    :type messages_traced_data: list of TracedData
+    :param analysis_dataset_configs: Analysis dataset configuration in pipeline configuration module.
+    :type analysis_dataset_configs: pipeline_config.analysis_configs.dataset_configurations
+    """
+    for analysis_dataset_config in analysis_dataset_configs:
+        constituency_coding_config = None
+        county_coding_config = None
+        location_engagement_db_datasets = None
+        for coding_config in analysis_dataset_config.coding_configs:
+            if coding_config.kenya_analysis_location == AnalysisLocations.KENYA_CONSTITUENCY:
+                log.info(f"Found kenya_analysis_location in county {coding_config.analysis_dataset} coding config")
+
+                assert constituency_coding_config is None, f"Found more than one constituency_coding_config in " \
+                    f"analysis_dataset_config, expected one crashing"
+                constituency_coding_config = coding_config
+                location_engagement_db_datasets = analysis_dataset_config.engagement_db_datasets
+
+            elif coding_config.kenya_analysis_location == AnalysisLocations.KENYA_COUNTY:
+                log.info(f"Found kenya_analysis_location in constituency {coding_config.analysis_dataset} coding config")
+
+                assert county_coding_config is None, f"Found more than one county_coding_config in " \
+                    f"analysis_dataset_config, expected one crashing"
+                county_coding_config = coding_config
+
+        if constituency_coding_config is None and county_coding_config is None:
+            continue
+
+        log.info("Imputing Kenyan location codes...")
+        _impute_location_codes(
+            user, messages_traced_data, location_engagement_db_datasets,
+            [
+                (constituency_coding_config, KenyaLocations.constituency_for_location_code),
+                (county_coding_config, KenyaLocations.county_for_location_code)
+            ]
+        )
+
+
 def _impute_kenya_location_codes(user, messages_traced_data, analysis_dataset_configs):
     """
     Imputes Kenya location labels for location dataset messages.
@@ -441,7 +573,7 @@ def impute_codes_by_message(user, messages_traced_data, analysis_dataset_configs
     _impute_not_reviewed_labels(user, messages_traced_data, analysis_dataset_configs, ws_correct_dataset_code_scheme)
     _impute_ws_coding_errors(user, messages_traced_data, analysis_dataset_configs, ws_correct_dataset_code_scheme)
     _impute_age_category(user, messages_traced_data, analysis_dataset_configs)
-    _impute_kenya_location_codes(user, messages_traced_data, analysis_dataset_configs)
+    _impute_kenya_location_codes_2(user, messages_traced_data, analysis_dataset_configs)
 
 
 def _impute_true_missing(user, column_traced_data_iterable, analysis_dataset_configs):


### PR DESCRIPTION
This generalises the implementation to make it much easier to add other locations, and demonstrates how to use this with a new _impute_kenya_location_codes() function.

(I've left the kenya_analysis_location configuraiton property's name as-is for now, but will change to analysis_location in a future PR)