### PR TITLE
Handle empty messages

### DIFF
--- a/src/engagement_db_coda_sync/engagement_db_to_coda.py
+++ b/src/engagement_db_coda_sync/engagement_db_to_coda.py
@@ -67,8 +67,14 @@ def _sync_next_engagement_db_message_to_coda(transaction, engagement_db, coda, c
         engagement_db_message = next_message_results[0]
         sync_stats.add_event(CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB)
 
-    log.info(f"Syncing message {engagement_db_message.message_id}...")
+    if engagement_db_message.text is None or engagement_db_message.text == "":
+        # Don't sync messages that don't have text
+        log.info(f"Message {engagement_db_message.message_id} is empty (.text == {engagement_db_message.text}), "
+                 f"not adding to Coda")
+        sync_stats.add_event(CodaSyncEvents.SKIP_EMPTY_MESSAGE)
+        return engagement_db_message, sync_stats
 
+    log.info(f"Syncing message {engagement_db_message.message_id}...")
     # Ensure the message has a valid coda id. If it doesn't have one yet, write one back to the database.
     if engagement_db_message.coda_id is None:
         log.debug("Creating coda id")

--- a/src/engagement_db_coda_sync/sync_stats.py
+++ b/src/engagement_db_coda_sync/sync_stats.py
@@ -8,6 +8,7 @@ log = Logger(__name__)
 class CodaSyncEvents:
     READ_MESSAGE_FROM_ENGAGEMENT_DB = "read_message_from_engagement_db"
     SET_CODA_ID = "set_coda_id"
+    SKIP_EMPTY_MESSAGE = "skip_empty_message"
     READ_MESSAGE_FROM_CODA = "read_message_from_coda"
     ADD_MESSAGE_TO_CODA = "add_message_to_coda"
     LABELS_MATCH = "labels_match"
@@ -20,6 +21,7 @@ class EngagementDBToCodaSyncStats(SyncStats):
         super().__init__({
             CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB: 0,
             CodaSyncEvents.SET_CODA_ID: 0,
+            CodaSyncEvents.SKIP_EMPTY_MESSAGE: 0,
             CodaSyncEvents.ADD_MESSAGE_TO_CODA: 0,
             CodaSyncEvents.LABELS_MATCH: 0,
             CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS: 0,
@@ -29,6 +31,7 @@ class EngagementDBToCodaSyncStats(SyncStats):
     def print_summary(self):
         log.info(f"Messages read from engagement db: {self.event_counts[CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB]}")
         log.info(f"Coda ids set: {self.event_counts[CodaSyncEvents.SET_CODA_ID]}")
+        log.info(f"Skipped messages with text None or '': {self.event_counts[CodaSyncEvents.SKIP_EMPTY_MESSAGE]}")
         log.info(f"Messages added to Coda: {self.event_counts[CodaSyncEvents.ADD_MESSAGE_TO_CODA]}")
         log.info(f"Messages updated with labels from Coda: {self.event_counts[CodaSyncEvents.UPDATE_ENGAGEMENT_DB_LABELS]}")
         log.info(f"Messages with labels already matching Coda: {self.event_counts[CodaSyncEvents.LABELS_MATCH]}")

--- a/src/engagement_db_to_analysis/code_imputation_functions.py
+++ b/src/engagement_db_to_analysis/code_imputation_functions.py
@@ -222,6 +222,42 @@ def _impute_ws_coding_errors(user, messages_traced_data, analysis_dataset_config
     log.info(f"Imputed {imputed_labels} {Codes.CODING_ERROR} labels for WS codes")
 
 
+def _impute_nc_for_empty_messages(user, messages_traced_data, analysis_dataset_configs, ws_correct_dataset_code_scheme):
+    """
+    Imputes Codes.NOT_CODED for messages whose text property is either None or "".
+
+    :param user: Identifier of user running the pipeline.
+    :type user: str
+    :param messages_traced_data: Messages TracedData objects to impute age_category.
+    :type messages_traced_data: list of TracedData
+    :param analysis_dataset_configs: Analysis dataset configuration in pipeline configuration module.
+    :type analysis_dataset_configs: pipeline_config.analysis_configs.dataset_configurations
+    :param ws_correct_dataset_code_scheme: WS - Correct Dataset code scheme.
+    :type ws_correct_dataset_code_scheme: core_data_modules.data_models.CodeScheme
+    """
+    messages_with_nc_imputed = 0
+    for message_td in messages_traced_data:
+        message = Message.from_dict(dict(message_td))
+
+        if not (message.text is None or message.text == ""):
+            continue
+
+        message_analysis_config = analysis_dataset_config_for_message(analysis_dataset_configs, message)
+        normal_code_schemes = [c.code_scheme for c in message_analysis_config.coding_configs]
+
+        _clear_latest_labels(user, message_td, normal_code_schemes + [ws_correct_dataset_code_scheme])
+        for code_scheme in normal_code_schemes:
+            nc_label = CleaningUtils.make_label_from_cleaner_code(
+                code_scheme, code_scheme.get_code_with_control_code(Codes.NOT_CODED),
+                Metadata.get_call_location()
+            )
+            _insert_label_to_message_td(user, message_td, nc_label)
+        messages_with_nc_imputed += 1
+
+    log.info(f"Processed {Codes.NOT_CODED} labels for empty messages: Searched {len(messages_traced_data)} messages and "
+             f"imputed {messages_with_nc_imputed} {Codes.NOT_CODED} labels")
+
+
 def _impute_age_category(user, messages_traced_data, analysis_dataset_configs):
     """
     Imputes age category for age dataset messages.
@@ -440,6 +476,8 @@ def impute_codes_by_message(user, messages_traced_data, analysis_dataset_configs
     """
     _impute_not_reviewed_labels(user, messages_traced_data, analysis_dataset_configs, ws_correct_dataset_code_scheme)
     _impute_ws_coding_errors(user, messages_traced_data, analysis_dataset_configs, ws_correct_dataset_code_scheme)
+    _impute_nc_for_empty_messages(user, messages_traced_data, analysis_dataset_configs, ws_correct_dataset_code_scheme)
+
     _impute_age_category(user, messages_traced_data, analysis_dataset_configs)
     _impute_kenya_location_codes(user, messages_traced_data, analysis_dataset_configs)
 


### PR DESCRIPTION
Empty messages are defined as None or "". Handles by:
 - Not attempting to upload to Coda (Coda's api rejects these anyway)
 - Automatically labelling as NC