### PR TITLE
Create common Cache

### DIFF
--- a/src/common/cache.py
+++ b/src/common/cache.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from os import path
+import json
+
+
+from core_data_modules.util import IOUtils
+from engagement_database.data_models import Message
+from temba_client.v2 import Contact
+
+
+class Cache:
+    def __init__(self, cache_dir):
+        """
+        Initialises an Engagement to Analysis cache at the given directory.
+        The cache can be used to locally save/retrieve data needed to enable incremental running of a
+        Engagement database-> Analysis tool.
+
+        :param cache_dir: Directory to use for the cache.
+        :type cache_dir: str
+        """
+        self.cache_dir = cache_dir
+
+    def set_date_time(self, entry_name, date_time):
+        export_path = f"{self.cache_dir}/{entry_name}.txt"
+        IOUtils.ensure_dirs_exist_for_file(export_path)
+        with open(export_path, "w") as f:
+            f.write(date_time.isoformat())
+
+    def get_date_time(self, entry_name):
+        try:
+            with open(f"{self.cache_dir}/{entry_name}.txt") as f:
+                return datetime.fromisoformat(f.read())
+        except FileNotFoundError:
+            return None
+
+    def set_rapid_pro_contacts(self, entry_name, contacts):
+        export_path = f"{self.cache_dir}/{entry_name}.json"
+        IOUtils.ensure_dirs_exist_for_file(export_path)
+        with open(export_path, "w") as f:
+            json.dump([c.serialize() for c in contacts], f)
+
+    def get_rapid_pro_contacts(self, entry_name):
+        try:
+            with open(f"{self.cache_dir}/{entry_name}.json") as f:
+                return [Contact.deserialize(d) for d in json.load(f)]
+        except FileNotFoundError:
+            return None
+
+    def set_message(self, entry_name, message):
+        export_path = f"{self.cache_dir}/{entry_name}.json"
+        IOUtils.ensure_dirs_exist_for_file(export_path)
+        with open(export_path, "w") as f:
+            json.dump(message.to_dict(serialize_datetimes_to_str=True), f)
+
+    def get_message(self, entry_name):
+        try:
+            with open(f"{self.cache_dir}/{entry_name}.json") as f:
+                return Message.from_dict(json.load(f))
+        except FileNotFoundError:
+            return None
+
+    def get_messages(self, entry_name):
+        previous_export_file_path = path.join(f"{self.cache_dir}/{entry_name}.jsonl")
+        messages = []
+        try:
+            with open(previous_export_file_path) as f:
+                for line in f:
+                    messages.append(Message.from_dict(json.loads(line)))
+        except FileNotFoundError:
+            return None
+
+        return messages
+
+    def set_messages(self, entry_name, messages):
+        export_file_path = path.join(f"{self.cache_dir}/{entry_name}.jsonl")
+        IOUtils.ensure_dirs_exist_for_file(export_file_path)
+        with open(export_file_path, "w") as f:
+            for msg in messages:
+                f.write(f"{json.dumps(msg.to_dict(serialize_datetimes_to_str=True))}\n")

--- a/src/engagement_db_coda_sync/cache.py
+++ b/src/engagement_db_coda_sync/cache.py
@@ -1,63 +1,47 @@
-from datetime import datetime
-import json
-
-from core_data_modules.util import IOUtils
-from engagement_database.data_models import Message
+from src.common.cache import Cache
 
 
-class CodaSyncCache:
-    def __init__(self, cache_dir):
-        """
-        Initialises a Coda sync cache at the given directory.
-
-        The sync cache can be used to locally save/retrieve data needed to enable incremental running of a
-        engagement database <-> Coda sync tools.
-
-        :param cache_dir: Directory to use for the cache.
-        :type cache_dir: str
-        """
-        self.cache_dir = cache_dir
-
-    def message_to_json(self, message):
-        message_dict = message.to_dict()
-        message_dict["timestamp"] = message_dict["timestamp"].isoformat()
-        message_dict["last_updated"] = message_dict["last_updated"].isoformat()
-        return json.dumps(message_dict)
-
-    def json_to_message(self, blob):
-        message_dict = json.loads(blob)
-        message_dict["timestamp"] = datetime.fromisoformat(message_dict["timestamp"])
-        message_dict["last_updated"] = datetime.fromisoformat(message_dict["last_updated"])
-        return Message.from_dict(message_dict)
-
-    def _last_seen_message_path(self, dataset):
-        return f"{self.cache_dir}/last-seen-message-{dataset}.json"
-
+class CodaSyncCache(Cache):
     def get_last_seen_message(self, dataset):
-        try:
-            with open(self._last_seen_message_path(dataset)) as f:
-                return self.json_to_message(f.read())
-        except FileNotFoundError:
-            return None
+        """
+        Gets the last seen engagement db message for the given dataset.
+
+        :param dataset: Dataset
+        :type dataset: str
+        :return: Last seen message, or None if there is no cached message for this dataset.
+        :rtype: engagement_database.data_models.Message | None
+        """
+        return self.get_message(dataset)
 
     def set_last_seen_message(self, dataset, message):
-        export_path = self._last_seen_message_path(dataset)
-        IOUtils.ensure_dirs_exist_for_file(export_path)
-        with open(export_path, "w") as f:
-            f.write(self.message_to_json(message))
+        """
+        Sets the last seen engagement db message for the given dataset.
 
-    def _last_updated_timestamp_path(self, dataset):
-        return f"{self.cache_dir}/last-updated-timestamp-{dataset}.txt"
+        :param dataset: Dataset
+        :type dataset: str
+        :param message: Last seen message
+        :type message: engagement_database.data_models.Message
+        """
+        return self.set_message(dataset, message)
 
     def get_last_updated_timestamp(self, dataset):
-        try:
-            with open(self._last_updated_timestamp_path(dataset)) as f:
-                return datetime.fromisoformat(f.read())
-        except FileNotFoundError:
-            return None
+        """
+        Gets the last_updated timestamp for the given dataset.
 
-    def set_last_updated_timestamp(self, dataset, last_updated_timestamp):
-        export_path = self._last_updated_timestamp_path(dataset)
-        IOUtils.ensure_dirs_exist_for_file(export_path)
-        with open(export_path, "w") as f:
-            f.write(last_updated_timestamp.isoformat())
+        :param dataset: Dataset
+        :type dataset: str
+        :return: Last updated timestamp, or None if there is no cached timestamp for this dataset.
+        :rtype: datetime.datetime | None
+        """
+        return self.get_date_time(dataset)
+
+    def set_last_updated_timestamp(self, dataset, timestamp):
+        """
+        Sets the last_updated timestamp for the given dataset.
+
+        :param dataset: Dataset
+        :type dataset: str
+        :param timestamp: Last updated timestamp to write.
+        :type timestamp: datetime.datetime | None
+        """
+        return self.set_date_time(dataset, timestamp)

--- a/src/engagement_db_to_analysis/cache.py
+++ b/src/engagement_db_to_analysis/cache.py
@@ -1,24 +1,7 @@
-from datetime import datetime
-from os import path
-import json
+from src.common.cache import Cache
 
 
-from core_data_modules.util import IOUtils
-from engagement_database.data_models import Message
-
-
-class AnalysisCache:
-    def __init__(self, cache_dir):
-        """
-        Initialises an Engagement to Analysis cache at the given directory.
-        The cache can be used to locally save/retrieve data needed to enable incremental running of a
-        Engagement database-> Analysis tool.
-
-        :param cache_dir: Directory to use for the cache.
-        :type cache_dir: str
-        """
-        self.cache_dir = cache_dir
-
+class AnalysisCache(Cache):
     def _latest_message_timestamp_path(self, engagement_db_dataset):
         return f"{self.cache_dir}/last_updated_{engagement_db_dataset}.txt"
 
@@ -31,57 +14,15 @@ class AnalysisCache:
         :return: Timestamp for the last updated message in cache, or None if there is no cache yet for this context.
         :rtype: datetime.datetime | None
         """
-        try:
-            with open(self._latest_message_timestamp_path(engagement_db_dataset)) as f:
-                return datetime.fromisoformat(f.read())
-        except FileNotFoundError:
-            return None
+        return self.get_date_time(engagement_db_dataset)
 
-    def set_latest_message_timestamp(self, engagement_db_dataset, last_updated):
+    def set_latest_message_timestamp(self, engagement_db_dataset, latest_timestamp):
         """
         Sets the latest seen message.last_updated in cache for the given engagement_db_dataset context.
 
         :param engagement_db_dataset: Engagement db dataset name for this context.
         :type engagement_db_dataset: str
-        :return: Latest run timestamp.
-        :rtype: datetime.datetime
+        :param latest_timestamp: Latest run timestamp.
+        :type latest_timestamp: datetime.datetime
         """
-        export_path = self._latest_message_timestamp_path(engagement_db_dataset)
-        IOUtils.ensure_dirs_exist_for_file(export_path)
-        with open(export_path, "w") as f:
-            f.write(last_updated.isoformat())
-
-    def get_messages(self, engagement_db_dataset):
-        """
-        Gets a list of messages for the given engagement_db_dataset from the cache.
-
-        :param engagement_db_dataset: Engagement db dataset name for this context.
-        :type engagement_db_dataset: str
-        :return: list of messages
-        :rtype: list of engagement_database.data_models.Message
-        """
-        previous_export_file_path = path.join(f"{self.cache_dir}/{engagement_db_dataset}.jsonl")
-        messages = []
-        try:
-            with open(previous_export_file_path) as f:
-                for line in f:
-                    messages.append(Message.from_dict(json.loads(line)))
-        except FileNotFoundError:
-            return []
-
-        return messages
-
-    def set_messages(self, engagement_db_dataset, messages):
-        """
-        Sets a list of messages for the given engagement_db_dataset.
-
-        :param engagement_db_dataset: Engagement db dataset name for this context.
-        :type engagement_db_dataset: str
-        :param messages: Messages to set, for the given engagement db dataset.
-        :type messages: list of engagement_database.data_models.Message
-        """
-        export_file_path = path.join(f"{self.cache_dir}/{engagement_db_dataset}.jsonl")
-        IOUtils.ensure_dirs_exist_for_file(export_file_path)
-        with open(export_file_path, "w") as f:
-            for msg in messages:
-                f.write(f"{json.dumps(msg.to_dict(serialize_datetimes_to_str=True))}\n")
+        self.set_date_time(engagement_db_dataset, latest_timestamp)

--- a/src/rapid_pro_to_engagement_db/cache.py
+++ b/src/rapid_pro_to_engagement_db/cache.py
@@ -1,39 +1,15 @@
-from datetime import datetime
-import json
-
-from core_data_modules.util import IOUtils
-from temba_client.v2 import Contact
+from src.common.cache import Cache
 
 
-class RapidProSyncCache:
-    def __init__(self, cache_dir):
-        """
-        Initialises a Rapid Pro sync cache at the given directory.
-
-        The sync cache can be used to locally save/retrieve data needed to enable incremental running of a
-        Rapid Pro -> Engagement Database sync tool.
-
-        :param cache_dir: Directory to use for the cache.
-        :type cache_dir: str
-        """
-
-        self.cache_dir = cache_dir
-
-    def _contacts_path(self):
-        return f"{self.cache_dir}/contacts.json"
-
+class RapidProSyncCache(Cache):
     def get_contacts(self):
         """
         Gets cached contacts.
 
-        :return: Cached contacts, or None if there is no cache yet.
+        :return: Cached contacts, or None if there is no contacts cache.
         :rtype: list of temba_client.v2.Contact | None
         """
-        try:
-            with open(self._contacts_path()) as f:
-                return [Contact.deserialize(d) for d in json.load(f)]
-        except FileNotFoundError:
-            return None
+        return self.get_rapid_pro_contacts("contacts")
 
     def set_contacts(self, contacts):
         """
@@ -42,13 +18,7 @@ class RapidProSyncCache:
         :return: Contacts to write to the cache.
         :rtype: list of temba_client.v2.Contact | None
         """
-        export_path = self._contacts_path()
-        IOUtils.ensure_dirs_exist_for_file(export_path)
-        with open(export_path, "w") as f:
-            json.dump([c.serialize() for c in contacts], f)
-
-    def _latest_run_timestamp_path(self, flow_id, result_field):
-        return f"{self.cache_dir}/latest_seen_run_{flow_id}_{result_field}.txt"
+        self.set_rapid_pro_contacts("contacts", contacts)
 
     def get_latest_run_timestamp(self, flow_id, result_field):
         """
@@ -58,16 +28,12 @@ class RapidProSyncCache:
         :type flow_id: str
         :param result_field: Flow result field.
         :type result_field: str
-        :return: Cached latest run timestamp, or None if there is no cache yet for this context.
+        :return: Cached latest run.modified_on, or None if there is no cached value for this context.
         :rtype: datetime.datetime | None
         """
-        try:
-            with open(self._latest_run_timestamp_path(flow_id, result_field)) as f:
-                return datetime.fromisoformat(f.read())
-        except FileNotFoundError:
-            return None
+        return self.get_date_time(f"{flow_id}.{result_field}")
 
-    def set_latest_run_timestamp(self, flow_id, result_field, last_updated):
+    def set_latest_run_timestamp(self, flow_id, result_field, timestamp):
         """
         Sets the latest seen run.modified_on cache for the given flow_id and result_field context.
 
@@ -75,10 +41,7 @@ class RapidProSyncCache:
         :type flow_id: str
         :param result_field: Flow result field.
         :type result_field: str
-        :return: Latest run timestamp.
-        :rtype: datetime.datetime
+        :param timestamp: Latest seen run.modified_on for the given floW_id and result_field context.
+        :type timestamp: datetime.datetime
         """
-        export_path = self._latest_run_timestamp_path(flow_id, result_field)
-        IOUtils.ensure_dirs_exist_for_file(export_path)
-        with open(export_path, "w") as f:
-            f.write(last_updated.isoformat())
+        self.set_date_time(f"{flow_id}.{result_field}", timestamp)


### PR DESCRIPTION
This reduces the maintenance costs of having many different cache implementations, and will allow stages to share some fetch functionality more easily when needed. 