### PR TITLE
Validate origin_ids are unique in analysis

### DIFF
--- a/src/engagement_db_to_analysis/engagement_db_to_analysis.py
+++ b/src/engagement_db_to_analysis/engagement_db_to_analysis.py
@@ -131,6 +131,16 @@ def _get_project_messages_from_engagement_db(analysis_dataset_configurations, en
                 if len(messages) > 0:
                     cache.set_messages(engagement_db_dataset, messages)
 
+    # Ensure that origin_ids in the exported messages are all unique. If we have multiple messages with the same
+    # origin_id, that means there is a problem with the database or with the cache.
+    # (Most likely we added the same message twice or we deleted a message and forgot to delete the analysis cache).
+    all_message_origins = set()
+    for messages in engagement_db_dataset_messages_map.values():
+        for msg in messages:
+            assert msg.origin.origin_id not in all_message_origins, f"Multiple messages had the same origin id: " \
+                                                                    f"'{msg.origin.origin_id}'"
+            all_message_origins.add(msg.origin.origin_id)
+
     return engagement_db_dataset_messages_map
 
 


### PR DESCRIPTION
If this fails, it means there is a problem with the database or a cache somewhere, so we should fail instead of proceeding to analyse problematic data.