### PR TITLE
Batch engagement db reads in coda -> db sync

### DIFF
--- a/src/engagement_db_coda_sync/coda_to_engagement_db.py
+++ b/src/engagement_db_coda_sync/coda_to_engagement_db.py
@@ -10,10 +10,10 @@ log = Logger(__name__)
 
 
 @firestore.transactional
-def _sync_coda_message_to_engagement_db(transaction, coda_message, engagement_db, engagement_db_dataset, coda_config):
+def _sync_coda_message_to_engagement_db_batch(transaction, coda_message, engagement_db, engagement_db_dataset,
+                                              coda_config, start_after=None):
     """
-    Syncs a coda message to an engagement database, by downloading all the engagement database messages which match the
-    coda message's id and dataset, and making sure the labels match.
+    Syncs a Coda message to a batch of up to 250 engagement database messages.
 
     :param transaction: Transaction in the engagement database to perform the update in.
     :type transaction: google.cloud.firestore.Transaction
@@ -27,18 +27,36 @@ def _sync_coda_message_to_engagement_db(transaction, coda_message, engagement_db
     :type coda_config: src.engagement_db_coda_sync.configuration.CodaSyncConfiguration
     :return Sync stats.
     :rtype src.engagement_db_coda_sync.sync_stats.CodaToEngagementDBSyncStats
+    :param start_after: Engagement database message to start this batch after.
+    :type start_after: engagement_database.data_models.Message
+    :return: Tuple of:
+                1. Next start_after message, or None. If a message, pass this into the next call to run the next
+                   batch correctly. If None, we've fetched the last message this batch so there are no further batches
+                   to run on.
+                2. Sync stats for this sync operation.
+    :rtype: (engagement_database.data_models.Message | None,
+             src.engagement_db_coda_sync.sync_stats.CodaToEngagementDBSyncStats)
     """
     sync_stats = CodaToEngagementDBSyncStats()
 
-    # Get the messages in the engagement database that match this dataset and coda message id
+    if start_after is None:
+        start_after_dict = {"last_updated": None, "message_id": None}
+    else:
+        start_after_dict = {"last_updated": start_after.last_updated, "message_id": start_after.message_id}
+
     engagement_db_messages = engagement_db.get_messages(
         firestore_query_filter=lambda q: q
             .where("dataset", "==", engagement_db_dataset)
             .where("coda_id", "==", coda_message.message_id)
-            .where("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE]),
+            .where("status", "in", [MessageStatuses.LIVE, MessageStatuses.STALE])
+            .order_by("last_updated")
+            .order_by("message_id")
+            .start_after(start_after_dict)
+            .limit(250),
         transaction=transaction
     )
-    log.info(f"{len(engagement_db_messages)} engagement db message(s) match Coda message {coda_message.message_id}")
+    log.info(f"{len(engagement_db_messages)} engagement db message(s) match Coda message {coda_message.message_id} "
+             f"in this batch")
 
     for _ in engagement_db_messages:
         sync_stats.add_event(CodaSyncEvents.READ_MESSAGE_FROM_ENGAGEMENT_DB)
@@ -50,6 +68,46 @@ def _sync_coda_message_to_engagement_db(transaction, coda_message, engagement_db
         message_sync_events = _update_engagement_db_message_from_coda_message(
             engagement_db, engagement_db_message, coda_message, coda_config, transaction=transaction)
         sync_stats.add_events(message_sync_events)
+
+    # If we downloaded a full-batch worth of messages, return a next_start_after document so the calling function
+    # knows to request another batch of messages to be updated.
+    next_start_after = None
+    if len(engagement_db_messages) == 250:
+        next_start_after = engagement_db_messages[-1]
+    return next_start_after, sync_stats
+
+
+def _sync_coda_message_to_engagement_db(coda_message, engagement_db, engagement_db_dataset, coda_config):
+    """
+    Syncs a coda message to an engagement database, by downloading all the engagement database messages which match the
+    coda message's id and dataset, and making sure the labels match.
+
+    :param coda_message: Coda Message to sync.
+    :type coda_message: core_data_modules.data_models.Message
+    :param engagement_db: Engagement database to sync from.
+    :type engagement_db: engagement_database.EngagementDatabase
+    :param engagement_db_dataset: Dataset in the engagement database to update.
+    :type engagement_db_dataset: str
+    :param coda_config: Configuration for the update.
+    :type coda_config: src.engagement_db_coda_sync.configuration.CodaSyncConfiguration
+    :return Sync stats.
+    :rtype src.engagement_db_coda_sync.sync_stats.CodaToEngagementDBSyncStats
+    """
+    sync_stats = CodaToEngagementDBSyncStats()
+
+    # Sync the coda message by fetching and updating the matching engagement db messages in 1 or more batches.
+    # (A multiple-batch approach is needed because the number of matching messages may exceed the Firestore batch limit)
+    start_after = None
+    first_run = True
+    batches = 0
+    while first_run or start_after is not None:
+        first_run = False
+        start_after, batch_sync_stats = _sync_coda_message_to_engagement_db_batch(
+            engagement_db.transaction(), coda_message, engagement_db, engagement_db_dataset, coda_config, start_after
+        )
+        sync_stats.add_stats(batch_sync_stats)
+        batches += 1
+        log.info(f"Synced {batches} batch(es) of engagement_db messages for coda_message {coda_message.message_id}")
 
     return sync_stats
 
@@ -83,8 +141,7 @@ def _sync_coda_dataset_to_engagement_db(coda, engagement_db, coda_config, datase
     for i, coda_message in enumerate(coda_messages):
         log.info(f"Processing Coda message {i + 1}/{len(coda_messages)}: {coda_message.message_id}...")
         message_sync_stats = _sync_coda_message_to_engagement_db(
-            engagement_db.transaction(), coda_message, engagement_db, dataset_config.engagement_db_dataset,
-            coda_config
+            coda_message, engagement_db, dataset_config.engagement_db_dataset, coda_config
         )
         sync_stats.add_stats(message_sync_stats)
 


### PR DESCRIPTION
This fixes the problem of pipelines crashing when a Coda message has more than 250 matching engagement db messages