### PR TITLE
Support multiple datasets per csv file, filtering by message timestamp

### DIFF
--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -42,7 +42,10 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
     csv_sources=[
         CSVSource(
             "gs://avf-project-datasets/2021/TEST-PIPELINE-ENGAGEMENT-DB/test_recovery.csv",
-            engagement_db_dataset="s01e01",
+            engagement_db_datasets=[
+                CSVDatasetConfiguration("s01e01", end_date=isoparse("2021-12-31T24:00:00+03:00")),
+                CSVDatasetConfiguration("age", start_date=isoparse("2022-01-01T00:00:00+03:00"))
+            ],
             timezone="Africa/Mogadishu"
         )
     ],

--- a/src/csv_to_engagement_db/configuration.py
+++ b/src/csv_to_engagement_db/configuration.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 import pytz
 
 

--- a/src/csv_to_engagement_db/configuration.py
+++ b/src/csv_to_engagement_db/configuration.py
@@ -1,12 +1,88 @@
-class CSVSource:
-    def __init__(self, gs_url, engagement_db_dataset, timezone):
-        self.gs_url = gs_url
+from datetime import datetime
+
+import pytz
+
+
+_MIN_DATE_UTC = pytz.timezone("utc").localize(datetime.min)
+_MAX_DATE_UTC = pytz.timezone("utc").localize(datetime.max)
+
+
+class CSVDatasetConfiguration:
+    def __init__(self, engagement_db_dataset, start_date=_MIN_DATE_UTC, end_date=_MAX_DATE_UTC):
+        """
+        Configuration for an engagement db dataset to sync csv messages to.
+
+        To restrict messages to this dataset by message timestamps, optionally set the `start_date`/`end_date`
+        properties.
+
+        :param engagement_db_dataset: Name of the dataset to use in the engagement database.
+        :type engagement_db_dataset: str
+        :param start_date: Start date for this dataset configuration.
+        :type start_date: datetime.datetime
+        :param end_date: End date for this dataset configuration.
+        :type end_date: datetime.datetime
+        """
         self.engagement_db_dataset = engagement_db_dataset
-        self.timezone = timezone
+        self.start_date = start_date
+        self.end_date = end_date
 
     def to_dict(self):
         return {
-            "gs_url": self.gs_url,
             "engagement_db_dataset": self.engagement_db_dataset,
+            "start_date": self.start_date,
+            "end_date": self.end_date
+        }
+
+
+class CSVSource:
+    def __init__(self, gs_url, engagement_db_datasets, timezone):
+        """
+        Configuration for a CSV data source. The CSV should have the headings 'Sender', 'Message', and 'ReceivedOn'.
+
+        :param gs_url: Google Cloud Storage URL to the csv file.
+        :type gs_url: str
+        :param engagement_db_datasets: Configuration for the engagement db datasets for this csv.
+        :type engagement_db_datasets: list of CSVDatasetConfiguration
+        :param timezone: Timezone to interpret the csv's timestamps in e.g. 'Africa/Nairobi'.
+        :type timezone: str
+        """
+        self.gs_url = gs_url
+        self.engagement_db_datasets = engagement_db_datasets
+        self.timezone = timezone
+
+    def get_dataset_for_timestamp(self, timestamp):
+        """
+        Gets the engagement db dataset for a message with the given timestamp, by searching the `engagement_db_datasets`
+        configurations for one which covers this time range.
+
+        Raises a LookupError if no matching dataset was found for this timestamp.
+        Raises an AssertionError if the timestamp matches multiple time ranges.
+
+        :param timestamp: Timestamp to get the engagement db dataset for.
+        :type timestamp: datetime.datetime
+        :return: Engagement db dataset for this timestamp.
+        :rtype: str
+        """
+        matching_dataset = None
+        for dataset in self.engagement_db_datasets:
+            if dataset.start_date <= timestamp < dataset.end_date:
+                assert matching_dataset is None, f"Timestamp {timestamp} matches multiple dataset time ranges"
+                matching_dataset = dataset.engagement_db_dataset
+
+        if matching_dataset is not None:
+            return matching_dataset
+
+        # No matching time range was found.
+        raise LookupError(timestamp)
+
+    def to_dict(self):
+        if self.engagement_db_datasets is None:
+            serialized_engagement_db_datasets = None
+        else:
+            serialized_engagement_db_datasets = [dataset.to_dict() for dataset in self.engagement_db_datasets]
+
+        return {
+            "gs_url": self.gs_url,
+            "engagement_db_datasets": serialized_engagement_db_datasets,
             "timezone": self.timezone
         }

--- a/src/csv_to_engagement_db/csv_to_engagement_db.py
+++ b/src/csv_to_engagement_db/csv_to_engagement_db.py
@@ -218,5 +218,6 @@ def sync_csvs_to_engagement_db(google_cloud_credentials_file_path, csv_sources, 
         source_to_sync_stats[csv_source.gs_url].print_summary()
         all_sync_stats.add_stats(source_to_sync_stats[csv_source.gs_url])
 
-    log.info(f"Summary of actions for all {len(csv_sources)} csv source(s): ")
+    dry_run_text = " (dry run)" if dry_run else ""
+    log.info(f"Summary of actions for all {len(csv_sources)} csv source(s){dry_run_text}:")
     all_sync_stats.print_summary()

--- a/src/csv_to_engagement_db/sync_stats.py
+++ b/src/csv_to_engagement_db/sync_stats.py
@@ -9,6 +9,7 @@ class CSVSyncEvents:
     READ_ROW_FROM_CSV = "read_row_from_csv"
     MESSAGE_ALREADY_IN_ENGAGEMENT_DB = "message_already_in_engagement_db"
     ADD_MESSAGE_TO_ENGAGEMENT_DB = "add_message_to_engagement_db"
+    MESSAGE_SKIPPED_NO_MATCHING_TIMESTAMP = "message_skipped_no_matching_timestamp"
 
 
 class CSVToEngagementDBSyncStats(SyncStats):
@@ -16,10 +17,12 @@ class CSVToEngagementDBSyncStats(SyncStats):
         super().__init__({
             CSVSyncEvents.READ_ROW_FROM_CSV: 0,
             CSVSyncEvents.MESSAGE_ALREADY_IN_ENGAGEMENT_DB: 0,
-            CSVSyncEvents.ADD_MESSAGE_TO_ENGAGEMENT_DB: 0
+            CSVSyncEvents.ADD_MESSAGE_TO_ENGAGEMENT_DB: 0,
+            CSVSyncEvents.MESSAGE_SKIPPED_NO_MATCHING_TIMESTAMP: 0
         })
 
     def print_summary(self):
         log.info(f"CSV rows read: {self.event_counts[CSVSyncEvents.READ_ROW_FROM_CSV]}")
         log.info(f"Messages already in engagement db: {self.event_counts[CSVSyncEvents.MESSAGE_ALREADY_IN_ENGAGEMENT_DB]}")
         log.info(f"Messages added to engagement db: {self.event_counts[CSVSyncEvents.ADD_MESSAGE_TO_ENGAGEMENT_DB]}")
+        log.info(f"Messages skipped because they didn't match a dataset time-range: {self.event_counts[CSVSyncEvents.MESSAGE_SKIPPED_NO_MATCHING_TIMESTAMP]}")

--- a/src/pipeline_configuration_spec.py
+++ b/src/pipeline_configuration_spec.py
@@ -9,7 +9,7 @@ from core_data_modules.analysis.traffic_analysis import TrafficLabel
 from src.common.configuration import (RapidProClientConfiguration, CodaClientConfiguration, UUIDTableClientConfiguration,
                                       EngagementDatabaseClientConfiguration, OperationsDashboardConfiguration,
                                       ArchiveConfiguration)
-from src.csv_to_engagement_db.configuration import CSVSource
+from src.csv_to_engagement_db.configuration import (CSVSource, CSVDatasetConfiguration)
 
 from src.engagement_db_coda_sync.configuration import (CodaSyncConfiguration, CodaDatasetConfiguration,
                                                        CodeSchemeConfiguration)


### PR DESCRIPTION
In #151 I suggested timestamp filters weren't a priority, especially as we could create one csv per dataset. However, having tried to use that configuration on the imaqal datasets, I've learned not having timestamp filtering makes things really tedious, and it makes adjusting dates really difficult. This makes configuring csvs earlier by allowing a single csv to point to multiple datasets.