### PR TITLE
Pass in configuration at docker run-time rather than build-time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,7 @@ ADD Pipfile.lock /app
 RUN pipenv sync
 
 # Copy the rest of the project
-ADD . /app
+ADD .git /app/.git
+ADD src /app/src
+ADD *.py /app
 

--- a/docker-sync-rapid-pro-to-engagement-db.sh
+++ b/docker-sync-rapid-pro-to-engagement-db.sh
@@ -26,22 +26,20 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Check that the correct number of arguments were provided.
-if [[ $# -ne 4 ]]; then
-    echo "Usage: $0 
+if [[ $# -ne 5 ]]; then
+    echo "Usage: $0
     [--dry-run] [--incremental-cache-volume <incremental-cache-volume>] 
     [--local-archive <local_archive>] : set a single option with argument, repeat it multiple times
-    <user> <google-cloud-credentials-file-path> <configuration-module> <data-dir>"
+    <user> <google-cloud-credentials-file-path> <configuration-file> <code-schemes-dir> <data-dir>"
     exit
 fi
 
 # Assign the program arguments to bash variables.
 USER=$1
 GOOGLE_CLOUD_CREDENTIALS_PATH=$2
-CONFIGURATION_MODULE=$3
-DATA_DIR=$4
-
-# Build an image for this pipeline stage.
-docker build -t "$IMAGE_NAME" .
+CONFIGURATION_FILE=$3
+CODE_SCHEMES_DIR=$4
+DATA_DIR=$5
 
 # Set local archive arguments if specified
 LOCAL_ARCHIVE_ARGS=""
@@ -54,7 +52,7 @@ done
 
 # Create a container from the image that was just built.
 CMD="pipenv run python -u sync_rapid_pro_to_engagement_db.py ${DRY_RUN} ${INCREMENTAL_ARG} ${LOCAL_ARCHIVE_ARGS} \
-    ${USER} /credentials/google-cloud-credentials.json ${CONFIGURATION_MODULE}"
+    ${USER} /credentials/google-cloud-credentials.json configuration"
 
 if [[ "$INCREMENTAL_ARG" ]]; then
     container="$(docker container create -w /app --mount source="$INCREMENTAL_CACHE_VOLUME_NAME",target=/cache "$IMAGE_NAME" /bin/bash -c "$CMD")"
@@ -68,6 +66,12 @@ container_short_id=${container:0:7}
 # Copy input data into the container
 echo "Copying $GOOGLE_CLOUD_CREDENTIALS_PATH -> $container_short_id:/credentials/google-cloud-credentials.json"
 docker cp "$GOOGLE_CLOUD_CREDENTIALS_PATH" "$container:/credentials/google-cloud-credentials.json"
+
+echo "Copying $CODE_SCHEMES_DIR -> $container_short_id:/app/code_schemes"
+docker cp "$CODE_SCHEMES_DIR" "$container:/app/code_schemes"
+
+echo "Copying $CONFIGURATION_FILE -> $container_short_id:/app/configuration.py"
+docker cp "$CONFIGURATION_FILE" "$container:/app/configuration.py"
 
 for LOCAL_ARCHIVE_PATH in "${LOCAL_ARCHIVE_PATHS[@]}"; do
     IFS="=" # Setting equal sign as delimiter 
@@ -91,5 +95,6 @@ if [[ "$INCREMENTAL_ARG" ]]; then
     mkdir -p "$DATA_DIR/Cache"
     docker cp "$container:/cache/." "$DATA_DIR/Cache"
 fi
+
 # Tear down the container when it has run successfully
 docker container rm "$container" >/dev/null


### PR DESCRIPTION
This will be useful for 2 reasons:
1. It makes it easy to test configurations in other repositories e.g. we could develop a code change against this repo while testing against a project-specific configuration without needing to copy that configuration into this repo first.
2. It makes docker images built against this repo reusable across other projects, because other projects will be able to simply copy in their configurations and run. This is another step towards reducing/removing copy-paste source code.

I've only made this change against one pipeline step for now, as the conversion is highly repetitive and I'd prefer to get feedback on this proof-of-concept than doing them all at once. If this is approved, I'll open another PR with similar changes to the remaining docker scripts then merge the 2 PRs together.