### PR TITLE
Make allow_clearing_fields non-optional

### DIFF
--- a/configurations/create_kenya_pool.py
+++ b/configurations/create_kenya_pool.py
@@ -206,7 +206,8 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                                         "kenya_pool_disabled", "kenya_pool_rqa"],
                 rapid_pro_contact_field=ContactField(key="engagement_db_consent_withdrawn", label="Engagement DB Consent Withdrawn")
             ),
-            write_mode=WriteModes.CONCATENATE_TEXTS
+            write_mode=WriteModes.CONCATENATE_TEXTS,
+            allow_clearing_fields=True
         )
     )
 )

--- a/configurations/test_pipeline_configuration.py
+++ b/configurations/test_pipeline_configuration.py
@@ -109,7 +109,10 @@ PIPELINE_CONFIGURATION = PipelineConfiguration(
                 engagement_db_datasets=["gender", "location", "age", "s01e01"],
                 rapid_pro_contact_field=ContactField(key="engagement_db_consent_withdrawn", label="Engagement DB Consent Withdrawn")
             ),
-            write_mode=WriteModes.CONCATENATE_TEXTS
+            write_mode=WriteModes.CONCATENATE_TEXTS,
+            # allow_clearing_fields is set somewhat arbitrarily here because this data isn't being used in flows.
+            # A pipeline that has continuous sync back in production will need to consider the options carefully.
+            allow_clearing_fields=True
         )
     ),
     analysis=AnalysisConfiguration(

--- a/src/engagement_db_to_rapid_pro/configuration.py
+++ b/src/engagement_db_to_rapid_pro/configuration.py
@@ -23,9 +23,10 @@ class DatasetConfiguration:
 
 @dataclass
 class EngagementDBToRapidProConfiguration:
+    # Whether to allow setting contact fields to empty. Setting this to True may not be appropriate for continuous
+    # sync because a new message may have arrived in Rapid Pro but not yet in the engagement database.
+    allow_clearing_fields: bool
     normal_datasets: Optional[List[DatasetConfiguration]] = None
     consent_withdrawn_dataset: Optional[DatasetConfiguration] = None
     write_mode: str = WriteModes.SHOW_PRESENCE
-    allow_clearing_fields: bool = False  # Whether to allow setting contact fields to empty. Setting this to True may
-                                         # not be appropriate for continuous sync because a new message may have arrived
-                                         # in Rapid Pro but not yet in the engagement database.
+


### PR DESCRIPTION
The default we were using wasn't sensible, as we should really be explicitly thinking about which option we want in every configuration.