### PR TITLE
Ensure the correct dataset != the message's current dataset

### DIFF
--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -298,6 +298,7 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
             correct_dataset = coda_config.default_ws_dataset
 
         # Ensure the message isn't being WS-corrected to the dataset it's already in.
+        # TODO: Handle this case without crashing.
         assert correct_dataset != engagement_db_message.dataset, \
             f"Engagement db message '{engagement_db_message.message_id}' (text '{engagement_db_message.text}') " \
             f"is being WS-corrected to dataset '{correct_dataset}', but is currently in this dataset already."

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -297,6 +297,11 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
                 raise e
             correct_dataset = coda_config.default_ws_dataset
 
+        # Ensure the message isn't being WS-corrected to the dataset it's already in.
+        assert correct_dataset != engagement_db_message.dataset, \
+            f"Engagement db message '{engagement_db_message.message_id}' (text '{engagement_db_message.text}') " \
+            f"is being WS-corrected to dataset '{correct_dataset}', but is currently in this dataset already."
+
         # Ensure this message isn't being moved to a dataset which it has previously been assigned to.
         # This is because if the message has already been in this new dataset, there is a chance there is an
         # infinite loop in the WS labels, which could get very expensive if we end up cycling this message through


### PR DESCRIPTION
This lets us find labelling errors earlier, and prevents the duplicated entry in previous_datasets (for example, under the previous code, if a message was, say, in a location dataset and labelled as WS -> location, it could be redirected to location once before the problem was detected. Then, after fixing the label, be redirected to age, leaving the prev_datasets as ["location", "location"], which isn't problematic, but does look slightly confusing)