### PR TITLE
Optionally set the correct_dataset from ws_code.string_value

### DIFF
--- a/src/engagement_db_coda_sync/configuration.py
+++ b/src/engagement_db_coda_sync/configuration.py
@@ -25,7 +25,7 @@ class CodaSyncConfiguration:
     dataset_configurations: [CodaDatasetConfiguration]
     ws_correct_dataset_code_scheme: CodeScheme
     project_users_file_url: Optional[str] = None
-    set_dataset_from_ws_match_value: bool = False
+    set_dataset_from_ws_string_value: bool = False
     default_ws_dataset: Optional[str] = None  # Engagement db dataset to move messages to if there is no dataset
                                               # configuration for a particular ws_code_string_value. If None, crashes if
                                               # a message is found with a WS label with a string value not in

--- a/src/engagement_db_coda_sync/configuration.py
+++ b/src/engagement_db_coda_sync/configuration.py
@@ -25,6 +25,7 @@ class CodaSyncConfiguration:
     dataset_configurations: [CodaDatasetConfiguration]
     ws_correct_dataset_code_scheme: CodeScheme
     project_users_file_url: Optional[str] = None
+    set_dataset_from_ws_match_value: bool = False
     default_ws_dataset: Optional[str] = None  # Engagement db dataset to move messages to if there is no dataset
                                               # configuration for a particular ws_code_string_value. If None, crashes if
                                               # a message is found with a WS label with a string value not in

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -288,11 +288,12 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
     # WS-correct if there is a valid ws_code
     if ws_code is not None:
         # Establish the correct dataset to move this message to.
-        # To determine the dataset, the following strategies are tried, in order:
-        #  1. Search the other dataset configurations for a match.
-        #  2. If `set_dataset_from_ws_string_value` has been set, move the message to the dataset `ws_code.string_value`
+        # To determine the dataset, the following strategies are tried, in this order:
+        #  1. Search the other dataset configurations for a match. If there is no match:
+        #  2. If `set_dataset_from_ws_string_value` has been set, move the message to the dataset
+        #     `ws_code.string_value`. Otherwise:
         #  3. If the `default_ws_dataset` has been specified, move the message to this default dataset.
-        #  4. Raise a ValueError.
+        # If no correct dataset is found after trying all these strategies, raise a ValueError.
         try:
             correct_dataset = \
                 coda_config.get_dataset_config_by_ws_code_string_value(ws_code.string_value).engagement_db_dataset

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -297,7 +297,7 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
             correct_dataset = \
                 coda_config.get_dataset_config_by_ws_code_string_value(ws_code.string_value).engagement_db_dataset
         except ValueError as e:
-            if coda_config.set_dataset_from_ws_match_value and ws_code.string_value in ws_code.match_values:
+            if coda_config.set_dataset_from_ws_string_value and ws_code.string_value in ws_code.match_values:
                 correct_dataset = ws_code.string_value
 
             # No dataset configuration found with an appropriate ws_code_string_value to move the message to.

--- a/src/engagement_db_coda_sync/lib.py
+++ b/src/engagement_db_coda_sync/lib.py
@@ -287,15 +287,25 @@ def _update_engagement_db_message_from_coda_message(engagement_db, engagement_db
 
     # WS-correct if there is a valid ws_code
     if ws_code is not None:
+        # Establish the correct dataset to move this message to.
+        # To determine the dataset, the following strategies are tried, in order:
+        #  1. Search the other dataset configurations for a match.
+        #  2. If `set_dataset_from_ws_string_value` has been set, move the message to the dataset `ws_code.string_value`
+        #  3. If the `default_ws_dataset` has been specified, move the message to this default dataset.
+        #  4. Raise a ValueError.
         try:
             correct_dataset = \
                 coda_config.get_dataset_config_by_ws_code_string_value(ws_code.string_value).engagement_db_dataset
         except ValueError as e:
+            if coda_config.set_dataset_from_ws_match_value and ws_code.string_value in ws_code.match_values:
+                correct_dataset = ws_code.string_value
+
             # No dataset configuration found with an appropriate ws_code_string_value to move the message to.
             # Fallback to the default dataset if available, otherwise crash.
-            if coda_config.default_ws_dataset is None:
+            elif coda_config.default_ws_dataset is not None:
+                correct_dataset = coda_config.default_ws_dataset
+            else:
                 raise e
-            correct_dataset = coda_config.default_ws_dataset
 
         # Ensure this message isn't being moved to a dataset which it has previously been assigned to.
         # This is because if the message has already been in this new dataset, there is a chance there is an


### PR DESCRIPTION
Copied from https://github.com/AfricasVoices/Project-RVI-Elections/pull/9/files, but put behind an optional flag this time so we don't use this behaviour by accident.