### PR TITLE
Serialize csv timestamp configuration in the origin details

### DIFF
--- a/src/csv_to_engagement_db/configuration.py
+++ b/src/csv_to_engagement_db/configuration.py
@@ -25,11 +25,11 @@ class CSVDatasetConfiguration:
         self.start_date = start_date
         self.end_date = end_date
 
-    def to_dict(self):
+    def to_dict(self, serialize_datetimes_to_str=False):
         return {
             "engagement_db_dataset": self.engagement_db_dataset,
-            "start_date": self.start_date,
-            "end_date": self.end_date
+            "start_date": self.start_date.isoformat() if serialize_datetimes_to_str else self.start_date,
+            "end_date": self.end_date.isoformat() if serialize_datetimes_to_str else self.end_date
         }
 
 
@@ -74,11 +74,13 @@ class CSVSource:
         # No matching time range was found.
         raise LookupError(timestamp)
 
-    def to_dict(self):
+    def to_dict(self, serialize_datetimes_to_str=False):
         if self.engagement_db_datasets is None:
             serialized_engagement_db_datasets = None
         else:
-            serialized_engagement_db_datasets = [dataset.to_dict() for dataset in self.engagement_db_datasets]
+            serialized_engagement_db_datasets = [
+                dataset.to_dict(serialize_datetimes_to_str) for dataset in self.engagement_db_datasets
+            ]
 
         return {
             "gs_url": self.gs_url,

--- a/src/csv_to_engagement_db/csv_to_engagement_db.py
+++ b/src/csv_to_engagement_db/csv_to_engagement_db.py
@@ -193,7 +193,7 @@ def _sync_csv_to_engagement_db(google_cloud_credentials_file_path, csv_source, e
         message_origin_details = {
             "csv_row_number": i,
             "csv_row_data": csv_msg,
-            "csv_sync_configuration": csv_source.to_dict(),
+            "csv_sync_configuration": csv_source.to_dict(serialize_datetimes_to_str=True),
             "csv_hash": csv_hash
         }
         sync_event = _ensure_engagement_db_has_message(engagement_db, engagement_db_message, message_origin_details, dry_run)


### PR DESCRIPTION
Without this fix, the origin.details in history entries contain DatetimeWithNanoseconds objects, which can't be json serialized, so we can't easily export history to disk. This forms one part of the solution, we'll also need to:
- [ ] Check if any other stages are impacted 
- [ ] Probably put a check for this in the db library so we don't accidentally have this problem somewhere else in future
- [ ] Figure out how to repair the entries already in the databases